### PR TITLE
Minor style changes and unit test bugfixes

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_CI: true
     steps:
       - uses: actions/checkout@v2
       - name: Set up python 3.6

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get Credential
         run: |
           mkdir -p ~/.local/share/neon
-          echo $CONNECTOR_CONFIG > ~/.local/share/neon/mq_config.json
+          echo $CONNECTOR_CONFIG > ~/.local/share/neon/credentials.json
         shell: bash
         env:
           CONNECTOR_CONFIG: ${{secrets.NEON_MQ_CONNECTOR_CONFIG}}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get Credential
         run: |
           mkdir -p ~/.local/share/neon
-          echo $NEON_MQ_CONNECTOR_CONFIG > ~/.local/share/neon/credentials.json
+          echo $CONNECTOR_CONFIG > ~/.local/share/neon/mq_config.json
         shell: bash
         env:
           CONNECTOR_CONFIG: ${{secrets.NEON_MQ_CONNECTOR_CONFIG}}

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -162,5 +162,8 @@ class MQConnector(ABC):
         if not names or len(names) == 0:
             names = list(self.consumers)
         for name in names:
-            if name in list(self.consumers):
-                self.consumers[name].join()
+            try:
+                if name in list(self.consumers):
+                    self.consumers[name].join()
+            except Exception as e:
+                raise ChildProcessError(e)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -58,8 +58,8 @@ class MQConnectorChild(MQConnector):
 class MQConnectorChildTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.file_path = 'config.json' if os.path.isfile("config.json") else "~/.local/share/neon/mq_config.json"
-        cls.connector_instance = MQConnectorChild(config=Configuration(file_path=cls.file_path).config_data,
+        file_path = 'config.json' if os.path.isfile("config.json") else "~/.local/share/neon/credentials.json"
+        cls.connector_instance = MQConnectorChild(config=Configuration(file_path=file_path).config_data,
                                                   service_name='test')
         cls.connector_instance.run_consumers(names=('test1', 'test2'))
 


### PR DESCRIPTION
Refactor ~/.local/share/neon/credentials.json to ~/.local/share/neon/mq_config.json for disambiguation
Update unit tests to read mq_config if config.json not available
Encapsulate child process errors in stop_consumers
Refactor test_connector imports to use relative file paths