### PR TITLE
More flexible config

### DIFF
--- a/neon_mq_connector/__init__.py
+++ b/neon_mq_connector/__init__.py
@@ -16,3 +16,4 @@
 # Specialized conversational reconveyance options from Conversation Processing Intelligence Corp.
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
+from connector import MQConnector

--- a/neon_mq_connector/config.py
+++ b/neon_mq_connector/config.py
@@ -19,13 +19,21 @@
 
 import os
 import json
+from typing import Optional
 
 
 class Configuration:
+    def __init__(self, file_path: Optional[str] = None):
+        self._config_data = dict()
+        if file_path:
+            self.from_file(file_path)
 
-    def __init__(self, file_path: str):
+    def from_file(self, file_path: str):
         with open(os.path.expanduser(file_path)) as input_file:
             self._config_data = json.load(input_file)
+
+    def from_dict(self, config_data: dict):
+        self._config_data = config_data
 
     @property
     def config_data(self) -> dict:

--- a/neon_mq_connector/config.py
+++ b/neon_mq_connector/config.py
@@ -22,6 +22,27 @@ import json
 from typing import Optional
 
 
+def load_neon_mq_config():
+    """
+    Locates and loads global MQ configuration
+    """
+    valid_config_paths = (
+        os.path.expanduser("~/.config/neon/mq_config.json"),
+        os.path.expanduser("~/.local/share/neon/credentials.json"),
+    )
+    config = None
+    for conf in valid_config_paths:
+        if os.path.isfile(conf):
+            config = Configuration().from_file(conf).config_data
+            break
+    if not config:
+        return
+    if "MQ" in config.keys():
+        return config["MQ"]
+    else:
+        return config
+
+
 class Configuration:
     def __init__(self, file_path: Optional[str] = None):
         self._config_data = dict()
@@ -31,9 +52,11 @@ class Configuration:
     def from_file(self, file_path: str):
         with open(os.path.expanduser(file_path)) as input_file:
             self._config_data = json.load(input_file)
+        return self
 
     def from_dict(self, config_data: dict):
         self._config_data = config_data
+        return self
 
     @property
     def config_data(self) -> dict:

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -27,6 +27,8 @@ from typing import Optional
 from neon_utils import LOG
 from neon_utils.socket_utils import dict_to_b64
 
+from neon_mq_connector.config import load_neon_mq_config
+
 
 class ConsumerThread(threading.Thread):
     """Rabbit MQ Consumer class that aims at providing unified configurable interface for consumer threads"""
@@ -76,11 +78,12 @@ class MQConnector(ABC):
             :param config: dictionary with current configurations.
                    { "users": {"<service_name>": { "username": "<username>",
                                                    "password": "<password>" },
-                     "server": "api.neon.ai"
+                     "server": "localhost",
+                     "port": 5672
                    }
             :param service_name: name of current service
        """
-        self.config = config
+        self.config = config or load_neon_mq_config()
         if self.config.get("MQ"):
             self.config = self.config["MQ"]
         self._service_id = self.create_unique_id()
@@ -140,7 +143,6 @@ class MQConnector(ABC):
             :raises Exception if self.config is not set
         """
         if not self.config:
-            # TODO: Call method in neon_utils?
             raise Exception('Configuration is not set')
         connection_params = pika.ConnectionParameters(host=self.config.get('server', 'localhost'),
                                                       port=int(self.config.get('port', '5672')),

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -19,6 +19,7 @@
 
 import uuid
 import pika
+import pika.exceptions
 import threading
 
 from abc import ABC, abstractmethod
@@ -72,10 +73,16 @@ class MQConnector(ABC):
     @abstractmethod
     def __init__(self, config: dict, service_name: str):
         """
-            :param config: dictionary with current configurations
+            :param config: dictionary with current configurations.
+                   { "users": {"<service_name>": { "username": "<username>",
+                                                   "password": "<password>" },
+                     "server": "api.neon.ai"
+                   }
             :param service_name: name of current service
        """
         self.config = config
+        if self.config.get("MQ"):
+            self.config = self.config["MQ"]
         self._service_id = self.create_unique_id()
         self.service_name = service_name
         self.consumers = dict()
@@ -89,8 +96,8 @@ class MQConnector(ABC):
         """Returns MQ Credentials object based on username and password in configuration"""
         if not self.config:
             raise Exception('Configuration is not set')
-        return pika.PlainCredentials(self.config['MQ']['users'][self.service_name].get('user', 'guest'),
-                                     self.config['MQ']['users'][self.service_name].get('password', 'guest'))
+        return pika.PlainCredentials(self.config['users'][self.service_name].get('user', 'guest'),
+                                     self.config['users'][self.service_name].get('password', 'guest'))
 
     @staticmethod
     def create_unique_id():
@@ -99,7 +106,7 @@ class MQConnector(ABC):
 
     @classmethod
     def emit_mq_message(cls, connection: pika.BlockingConnection, queue: str, request_data: dict,
-                        exchange: Optional[str]) -> int:
+                        exchange: Optional[str]) -> str:
         """
             Emits request to the neon api service on the MQ bus
 
@@ -133,9 +140,10 @@ class MQConnector(ABC):
             :raises Exception if self.config is not set
         """
         if not self.config:
+            # TODO: Call method in neon_utils?
             raise Exception('Configuration is not set')
-        connection_params = pika.ConnectionParameters(host=self.config['MQ'].get('server', 'localhost'),
-                                                      port=int(self.config['MQ'].get('port', '5672')),
+        connection_params = pika.ConnectionParameters(host=self.config.get('server', 'localhost'),
+                                                      port=int(self.config.get('port', '5672')),
                                                       virtual_host=vhost,
                                                       credentials=self.mq_credentials,
                                                       **kwargs)


### PR DESCRIPTION
Adds option for `MQ` config to be passed in addition to global config with `MQ` as a top-level key
Optionally reads config from standard locations if not provided
Updates `Configuration` class to build config from dict or JSON file