### PR TITLE
Limit message handling by consumer threads

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -41,11 +41,11 @@ class ConsumerThread(threading.Thread):
         self.callback_func = callback_func
         self.queue = queue
         self.channel = self.connection.channel()
-        self.channel.basic_qos()  # TODO: Add prefetch_count limit and check message ack DM
+        self.channel.basic_qos(prefetch_count=50)
         self.channel.queue_declare(queue=self.queue, auto_delete=False)
         self.channel.basic_consume(on_message_callback=self.callback_func,
                                    queue=self.queue,
-                                   auto_ack=False)
+                                   auto_ack=True)
 
     def run(self):
         """Creating consumer channel"""


### PR DESCRIPTION
Replace prefetch_count limit
Set auto_ack to True to ensure queue is cleared on message handling