### PR TITLE
Resolve errors closing connections, Add Error Handling

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -39,7 +39,7 @@ class ConsumerThread(threading.Thread):
     """Rabbit MQ Consumer class that aims at providing unified configurable interface for consumer threads"""
 
     def __init__(self, connection_params: pika.ConnectionParameters, queue: str, callback_func: callable,
-                 error_func: callable, *args, **kwargs):
+                 error_func: callable = None, *args, **kwargs):
         """
             :param connection_params: pika connection parameters
             :param queue: Desired consuming queue

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -30,18 +30,32 @@ from neon_utils.socket_utils import dict_to_b64
 from neon_mq_connector.config import load_neon_mq_config
 
 
+def handle_error(thread, exception):
+    # TODO: Depreciate this method DM
+    LOG.error(exception)
+
+
 class ConsumerThread(threading.Thread):
     """Rabbit MQ Consumer class that aims at providing unified configurable interface for consumer threads"""
 
-    def __init__(self, connection: pika.BlockingConnection, queue: str, callback_func: callable, *args, **kwargs):
+    def __init__(self, connection_params: pika.ConnectionParameters, queue: str, callback_func: callable,
+                 error_func: callable, *args, **kwargs):
         """
-            :param connection: MQ connection object
+            :param connection_params: pika connection parameters
             :param queue: Desired consuming queue
             :param callback_func: logic on message receiving
+            :param error_func: handler for consumer thread errors
         """
         threading.Thread.__init__(self, *args, **kwargs)
-        self.connection = connection
+
+        if isinstance(connection_params, pika.BlockingConnection):
+            # TODO: Depreciate this check DM
+            LOG.error("Passing a connection object is depreciated, update to pass connection parameters")
+            self.connection = connection_params
+        else:
+            self.connection = pika.BlockingConnection(connection_params)
         self.callback_func = callback_func
+        self.error_func = error_func or handle_error
         self.queue = queue
         self.channel = self.connection.channel()
         self.channel.basic_qos(prefetch_count=50)
@@ -55,24 +69,20 @@ class ConsumerThread(threading.Thread):
         super(ConsumerThread, self).run()
         try:
             self.channel.start_consuming()
-        except pika.exceptions.ChannelWrongStateError:
-            LOG.error("Channel not open!")
         except pika.exceptions.ChannelClosed:
-            pass
-        except pika.exceptions.StreamLostError as e:
-            LOG.error(f'Consuming error: {e}')
-        except Exception as x:
-            LOG.error(x)
-        LOG.debug(f"Consumer Thread stopped: {self.callback_func}")
+            LOG.debug(f"Channel closed by broker: {self.callback_func}")
+        except Exception as e:
+            LOG.error(e)
+            self.error_func(self, e)
 
     def join(self, timeout: Optional[float] = ...) -> None:
         """Terminating consumer channel"""
         try:
-            self.channel.close()
-            self.connection.close()
-        except pika.exceptions.StreamLostError as e:
-            pass
-            # LOG.error(f'Consuming error: {e}')
+            self.channel.stop_consuming()
+            if self.channel.is_open:
+                self.channel.close()
+            if self.connection.is_open:
+                self.connection.close()
         except Exception as x:
             LOG.error(x)
         finally:
@@ -111,6 +121,17 @@ class MQConnector(ABC):
             raise Exception('Configuration is not set')
         return pika.PlainCredentials(self.config['users'][self.service_name].get('user', 'guest'),
                                      self.config['users'][self.service_name].get('password', 'guest'))
+
+    def get_connection_params(self, vhost, **kwargs) -> pika.ConnectionParameters:
+        """
+        Gets connection parameters to be used to create an mq connection
+        """
+        connection_params = pika.ConnectionParameters(host=self.config.get('server', 'localhost'),
+                                                      port=int(self.config.get('port', '5672')),
+                                                      virtual_host=vhost,
+                                                      credentials=self.mq_credentials,
+                                                      **kwargs)
+        return connection_params
 
     @staticmethod
     def create_unique_id():
@@ -154,12 +175,26 @@ class MQConnector(ABC):
         """
         if not self.config:
             raise Exception('Configuration is not set')
-        connection_params = pika.ConnectionParameters(host=self.config.get('server', 'localhost'),
-                                                      port=int(self.config.get('port', '5672')),
-                                                      virtual_host=vhost,
-                                                      credentials=self.mq_credentials,
-                                                      **kwargs)
-        return pika.BlockingConnection(parameters=connection_params)
+        return pika.BlockingConnection(parameters=self.get_connection_params(vhost, **kwargs))
+
+    def register_consumer(self, name: str, vhost: str, queue: str,
+                          callback: callable, on_error: Optional[callable] = None):
+        """
+        Registers a consumer for the specified queue. The callback function will handle items in the queue.
+        Any raised exceptions will be passed as arguments to on_error.
+        :param name: Human readable name of the consumer
+        :param vhost: vhost to register on
+        :param queue: MQ Queue to read messages from
+        :param callback: Method to passed queued messages to
+        :param on_error: Optional method to handle any exceptions raised in message handling
+        """
+        error_handler = on_error or self.default_error_handler
+        self.consumers[name] = ConsumerThread(self.get_connection_params(vhost), queue=queue, callback_func=callback,
+                                              error_func=error_handler)
+
+    @staticmethod
+    def default_error_handler(thread: ConsumerThread, exception: Exception):
+        LOG.error(f"{exception} occurred in {thread}")
 
     def run_consumers(self, names: tuple = (), daemon=True):
         """

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -40,18 +40,29 @@ class MQConnectorChild(MQConnector):
         self.func_2_ok = True
         channel.basic_ack(delivery_tag=method.delivery_tag)
 
+    def callback_func_error(self, channel, method, properties, body):
+        raise Exception("Exception to Handle")
+
+    def handle_error(self, thread: ConsumerThread, exception: Exception):
+        self.exception = exception
+
     def __init__(self, config: dict, service_name: str):
         super().__init__(config=config, service_name=service_name)
         self.vhost = '/test'
         self.func_1_ok = False
         self.func_2_ok = False
+        self.exception = None
         self.connection = self.create_mq_connection(vhost=self.vhost)
-        self.consumers = dict(test1=ConsumerThread(connection=self.create_mq_connection(vhost=self.vhost),
+        self.consumers = dict(test1=ConsumerThread(connection_params=self.get_connection_params(vhost=self.vhost),
                                                    queue='test',
                                                    callback_func=self.callback_func_1),
-                              test2=ConsumerThread(connection=self.create_mq_connection(vhost=self.vhost),
+                              test2=ConsumerThread(connection_params=self.get_connection_params(vhost=self.vhost),
                                                    queue='test1',
-                                                   callback_func=self.callback_func_2)
+                                                   callback_func=self.callback_func_2),
+                              error=ConsumerThread(connection_params=self.get_connection_params(vhost=self.vhost),
+                                                   queue='error',
+                                                   callback_func=self.callback_func_error,
+                                                   error_func=self.handle_error)
                               )
 
 
@@ -61,12 +72,12 @@ class MQConnectorChildTest(unittest.TestCase):
         file_path = 'config.json' if os.path.isfile("config.json") else "~/.local/share/neon/credentials.json"
         cls.connector_instance = MQConnectorChild(config=Configuration(file_path=file_path).config_data,
                                                   service_name='test')
-        cls.connector_instance.run_consumers(names=('test1', 'test2'))
+        cls.connector_instance.run_consumers(names=('test1', 'test2', 'error'))
 
     @classmethod
     def tearDownClass(cls) -> None:
         try:
-            cls.connector_instance.stop_consumers(names=('test1', 'test2'))
+            cls.connector_instance.stop_consumers(names=('test1', 'test2', 'error'))
         except ChildProcessError as e:
             LOG.error(e)
         try:
@@ -74,15 +85,15 @@ class MQConnectorChildTest(unittest.TestCase):
         except pika.exceptions.StreamLostError as e:
             LOG.error(f'Consuming error: {e}')
 
-    def test_01_not_null_service_id(self):
+    def test_not_null_service_id(self):
         self.assertIsNotNone(self.connector_instance.service_id)
 
     @pytest.mark.timeout(30)
-    def test_02_connection_alive(self):
+    def test_connection_alive(self):
         self.assertIsInstance(self.connector_instance.consumers['test1'], ConsumerThread)
 
     @pytest.mark.timeout(30)
-    def test_03_produce(self):
+    def test_produce(self):
         self.channel = self.connector_instance.connection.channel()
         self.channel.basic_publish(exchange='',
                                    routing_key='test',
@@ -102,3 +113,18 @@ class MQConnectorChildTest(unittest.TestCase):
         time.sleep(3)
         self.assertTrue(self.connector_instance.func_1_ok)
         self.assertTrue(self.connector_instance.func_2_ok)
+
+    @pytest.mark.timeout(30)
+    def test_error(self):
+        self.channel = self.connector_instance.connection.channel()
+        self.channel.basic_publish(exchange='',
+                                   routing_key='error',
+                                   body='test',
+                                   properties=pika.BasicProperties(
+                                       expiration='3000'
+                                   ))
+        self.channel.close()
+
+        time.sleep(3)
+        self.assertIsInstance(self.connector_instance.exception, Exception)
+        self.assertEqual(str(self.connector_instance.exception), "Exception to Handle")


### PR DESCRIPTION
Move consumer definition inside ConsumerThread init to resolve errors on channel close (https://github.com/pika/pika/issues/1144#issuecomment-521026912)
Add error_func to handle any exceptions raised in consumers
Add unit testing of error callback
Adds `register_consumer` convenience method
TODO: Drop compatibility checks before push to master


Adds functionality to address: https://github.com/NeonGeckoCom/neon_api_proxy/issues/18