### PR TITLE
Support for synchronization, generic instance running initiation/termination, retry mechanism

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -246,7 +246,7 @@ class MQConnector(ABC):
 
     def run(self, retries_made: int = 0):
         """Generic method called on running the instance"""
-        if retries_made < self.Addconsumer_retries:
+        if retries_made < self.consumer_retries:
             try:
                 self.run_consumers()
                 self.sync_thread.start()

--- a/neon_mq_connector/utils/__init__.py
+++ b/neon_mq_connector/utils/__init__.py
@@ -18,4 +18,4 @@
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
 from .thread_utils import RepeatingTimer
-from .connection_utils import get_timeout
+from .connection_utils import retry

--- a/neon_mq_connector/utils/__init__.py
+++ b/neon_mq_connector/utils/__init__.py
@@ -1,0 +1,21 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+#
+# Copyright 2008-2021 Neongecko.com Inc. | All Rights Reserved
+#
+# Notice of License - Duplicating this Notice of License near the start of any file containing
+# a derivative of this software is a condition of license for this software.
+# Friendly Licensing:
+# No charge, open source royalty free use of the Neon AI software source and object is offered for
+# educational users, noncommercial enthusiasts, Public Benefit Corporations (and LLCs) and
+# Social Purpose Corporations (and LLCs). Developers can contact developers@neon.ai
+# For commercial licensing, distribution of derivative works or redistribution please contact licenses@neon.ai
+# Distributed on an "AS IS” basis without warranties or conditions of any kind, either express or implied.
+# Trademarks of Neongecko: Neon AI(TM), Neon Assist (TM), Neon Communicator(TM), Klat(TM)
+# Authors: Guy Daniels, Daniel McKnight, Elon Gasper, Richard Leeds, Kirill Hrymailo
+#
+# Specialized conversational reconveyance options from Conversation Processing Intelligence Corp.
+# US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
+# China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
+
+from .thread_utils import RepeatingTimer
+from .connection_utils import get_timeout

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -16,6 +16,9 @@
 # Specialized conversational reconveyance options from Conversation Processing Intelligence Corp.
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
+import time
+
+from neon_utils import LOG
 
 
 def get_timeout(backoff_factor: float, number_of_retries: int) -> float:
@@ -32,3 +35,49 @@ def get_timeout(backoff_factor: float, number_of_retries: int) -> float:
             >>> assert timeout == 0.2
     """
     return backoff_factor * (2 ** (number_of_retries - 1))
+
+
+def retry(callback_on_exceeded: str = None, callback_on_attempt_failure: str = None, num_retries: int = 3,
+          backoff_factor: int = 5, callback_on_attempt_failure_args: list = None, callback_on_exceeded_args: list = None):
+    """
+        Decorator for generic retrying function execution
+
+        :param num_retries: num of retries for function execution
+        :param callback_on_exceeded: function to call when all attempts fail
+        :param callback_on_exceeded_args: args for :param callback_on_exceeded
+        :param callback_on_attempt_failure: function to call when single attempt fails
+        :param callback_on_attempt_failure_args: args for :param callback_on_attempt_failure
+        :param backoff_factor: value of backoff factor for setting delay between function execution retry,
+                               refer to "get_timeout()" for details
+    """
+
+    if not callback_on_attempt_failure_args:
+        callback_on_attempt_failure_args = []
+    if not callback_on_exceeded_args:
+        callback_on_exceeded_args = []
+    def decorator(function):
+        def wrapper(self, num_attempts: int = 0, *args, **kwargs):
+            try:
+                function(self, *args, **kwargs)
+            except Exception as e:
+                for i in range(len(callback_on_attempt_failure_args)):
+                    if callback_on_attempt_failure_args[i] == 'e':
+                        callback_on_attempt_failure_args[i] = e
+                    elif callback_on_attempt_failure_args[i] == 'self':
+                        callback_on_attempt_failure_args[i] = self
+                if callback_on_attempt_failure:
+                    getattr(self, callback_on_attempt_failure)(*callback_on_attempt_failure_args)
+                sleep_timeout = get_timeout(backoff_factor=backoff_factor, number_of_retries=num_attempts)
+                LOG.error(f'{function} execution failed due to exception: {e}. Timeout for {sleep_timeout} secs')
+                time.sleep(sleep_timeout)
+                if num_attempts < num_retries:
+                    num_attempts += 1
+                    LOG.info(f'Retrying {function} execution. Attempt #{num_attempts}')
+                    wrapper(self, num_attempts=num_attempts+1, *args, **kwargs)
+                else:
+                    LOG.error(f'Failed to execute function after {num_retries} attempts')
+                    if callback_on_exceeded:
+                        getattr(self, callback_on_exceeded)(*callback_on_exceeded_args)
+        return wrapper
+    return decorator
+

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -1,0 +1,34 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+#
+# Copyright 2008-2021 Neongecko.com Inc. | All Rights Reserved
+#
+# Notice of License - Duplicating this Notice of License near the start of any file containing
+# a derivative of this software is a condition of license for this software.
+# Friendly Licensing:
+# No charge, open source royalty free use of the Neon AI software source and object is offered for
+# educational users, noncommercial enthusiasts, Public Benefit Corporations (and LLCs) and
+# Social Purpose Corporations (and LLCs). Developers can contact developers@neon.ai
+# For commercial licensing, distribution of derivative works or redistribution please contact licenses@neon.ai
+# Distributed on an "AS IS” basis without warranties or conditions of any kind, either express or implied.
+# Trademarks of Neongecko: Neon AI(TM), Neon Assist (TM), Neon Communicator(TM), Klat(TM)
+# Authors: Guy Daniels, Daniel McKnight, Elon Gasper, Richard Leeds, Kirill Hrymailo
+#
+# Specialized conversational reconveyance options from Conversation Processing Intelligence Corp.
+# US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
+# China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
+
+
+def get_timeout(backoff_factor: float, number_of_retries: int) -> float:
+    """
+        Gets timeout based on backoff_factor
+
+        Examples:
+            >>> __backoff_factor, __number_of_retries = 0.1, 1
+            >>> timeout = get_timeout(__backoff_factor, __number_of_retries)
+            >>> assert timeout == 0.1
+            >>>
+            >>> __backoff_factor, __number_of_retries = 0.1, 2
+            >>> timeout = get_timeout(__backoff_factor, __number_of_retries)
+            >>> assert timeout == 0.2
+    """
+    return backoff_factor * (2 ** (number_of_retries - 1))

--- a/neon_mq_connector/utils/thread_utils.py
+++ b/neon_mq_connector/utils/thread_utils.py
@@ -1,0 +1,28 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+#
+# Copyright 2008-2021 Neongecko.com Inc. | All Rights Reserved
+#
+# Notice of License - Duplicating this Notice of License near the start of any file containing
+# a derivative of this software is a condition of license for this software.
+# Friendly Licensing:
+# No charge, open source royalty free use of the Neon AI software source and object is offered for
+# educational users, noncommercial enthusiasts, Public Benefit Corporations (and LLCs) and
+# Social Purpose Corporations (and LLCs). Developers can contact developers@neon.ai
+# For commercial licensing, distribution of derivative works or redistribution please contact licenses@neon.ai
+# Distributed on an "AS IS” basis without warranties or conditions of any kind, either express or implied.
+# Trademarks of Neongecko: Neon AI(TM), Neon Assist (TM), Neon Communicator(TM), Klat(TM)
+# Authors: Guy Daniels, Daniel McKnight, Elon Gasper, Richard Leeds, Kirill Hrymailo
+#
+# Specialized conversational reconveyance options from Conversation Processing Intelligence Corp.
+# US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
+# China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
+
+from threading import Timer
+
+
+class RepeatingTimer(Timer):
+    """Timer thread that repeats calling function every self.interval seconds"""
+    def run(self):
+        """thread run function"""
+        while not self.finished.wait(self.interval):
+            self.function(*self.args, **self.kwargs)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -58,11 +58,11 @@ class MQConnectorChild(MQConnector):
         self.callback_ok = False
         self.exception = None
         self.register_consumer(name="test1", vhost=self.vhost, queue='test', callback=self.callback_func_1,
-                               auto_ack=True)
+                               auto_ack=False)
         self.register_consumer(name="test2", vhost=self.vhost, queue='test1', callback=self.callback_func_2,
-                               auto_ack=True)
+                               auto_ack=False)
         self.register_consumer(name="error", vhost=self.vhost, queue="error", callback=self.callback_func_error,
-                               on_error=self.handle_error, auto_ack=True)
+                               on_error=self.handle_error, auto_ack=False)
 
 
 class MQConnectorChildTest(unittest.TestCase):


### PR DESCRIPTION
Added support for synchronization signals in MQ Connector and generic run/stop methods. Also added generic retry() decorator into utils, but did not add direct support for it, as it is noticed to cause some thread-licking issues