### PR TITLE
Update config handling

### DIFF
--- a/neon_mq_connector/config.py
+++ b/neon_mq_connector/config.py
@@ -24,12 +24,15 @@ from typing import Optional
 
 def load_neon_mq_config():
     """
-    Locates and loads global MQ configuration
+    Locates and loads global MQ configuration. Priority is as follows:
+    NEON_MQ_CONFIG_PATH environment variable
+    {NEON_CONFIG_PATH}/mq_config.json
+    ~/.local/share/neon/credentials.json
     """
     valid_config_paths = (
-        os.environ.get('NEON_MQ_CONFIG_PATH'),
-        os.path.expanduser("~/.config/neon/mq_config.json"),
-        os.path.expanduser("~/.local/share/neon/credentials.json"),
+        os.path.expanduser(os.environ.get('NEON_MQ_CONFIG_PATH')),
+        os.path.join(os.path.expanduser(os.environ.get("NEON_CONFIG_PATH", "~/.config/neon")), "mq_config.json"),
+        os.path.expanduser("~/.local/share/neon/credentials.json")
     )
     config = None
     for conf in valid_config_paths:

--- a/neon_mq_connector/config.py
+++ b/neon_mq_connector/config.py
@@ -30,7 +30,7 @@ def load_neon_mq_config():
     ~/.local/share/neon/credentials.json
     """
     valid_config_paths = (
-        os.path.expanduser(os.environ.get('NEON_MQ_CONFIG_PATH')),
+        os.path.expanduser(os.environ.get('NEON_MQ_CONFIG_PATH', "")),
         os.path.join(os.path.expanduser(os.environ.get("NEON_CONFIG_PATH", "~/.config/neon")), "mq_config.json"),
         os.path.expanduser("~/.local/share/neon/credentials.json")
     )

--- a/neon_mq_connector/config.py
+++ b/neon_mq_connector/config.py
@@ -27,12 +27,13 @@ def load_neon_mq_config():
     Locates and loads global MQ configuration
     """
     valid_config_paths = (
+        os.environ.get('NEON_MQ_CONFIG_PATH'),
         os.path.expanduser("~/.config/neon/mq_config.json"),
         os.path.expanduser("~/.local/share/neon/credentials.json"),
     )
     config = None
     for conf in valid_config_paths:
-        if os.path.isfile(conf):
+        if conf and os.path.isfile(conf):
             config = Configuration().from_file(conf).config_data
             break
     if not config:

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -84,7 +84,7 @@ class MQConnector(ABC):
     """Abstract method for attaching services to MQ cluster"""
 
     @abstractmethod
-    def __init__(self, config: dict, service_name: str):
+    def __init__(self, config: Optional[dict], service_name: str):
         """
             :param config: dictionary with current configurations.
             ``` JSON Template of configuration:


### PR DESCRIPTION
Update MQ Connector to optionally read NEON_MQ_CONFIG_PATH envvar to match functionality in neon_api_proxy
Mark MQConnector config param as optional