### PR TITLE
Wait for MQ Server for Docker Compose support

### DIFF
--- a/neon_mq_connector/utils/__init__.py
+++ b/neon_mq_connector/utils/__init__.py
@@ -18,4 +18,4 @@
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
 from .thread_utils import RepeatingTimer
-from .connection_utils import retry
+from .connection_utils import retry, wait_for_mq_startup

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -20,6 +20,7 @@ import time
 from typing import Union, Callable
 
 from neon_utils import LOG
+from neon_utils.net_utils import check_port_is_open
 
 
 def get_timeout(backoff_factor: float, number_of_retries: int) -> float:
@@ -97,3 +98,17 @@ def retry(callback_on_exceeded: Union[str, Callable] = None, callback_on_attempt
         return wrapper
     return decorator
 
+
+def wait_for_mq_startup(addr: str, port: int, timeout: int = 60) -> bool:
+    """
+    Wait up to `timeout` seconds for the MQ connection at `addr`:`port` to come online.
+    :param addr: URL or IP address to monitor
+    :param port: MQ port to query
+    :param timeout: Max seconds to wait for connection to come online
+    """
+    stop_time = time.time() + timeout
+    while not check_port_is_open(addr, port):
+        LOG.debug("Waiting for MQ server to come online")
+        if time.time() > stop_time:
+            return False
+    return True

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,3 @@
 pika==1.2.0
-neon_utils>=0.5.7
+# TODO: update to non-alpha version
+neon_utils~=0.12.7a1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from neon_mq_connector.utils import RepeatingTimer
-from neon_mq_connector.utils.connection_utils import get_timeout, retry
+from neon_mq_connector.utils.connection_utils import get_timeout, retry, wait_for_mq_startup
 
 
 def callback_on_failure():
@@ -85,6 +85,10 @@ class TestMQConnectorUtils(unittest.TestCase):
         time.sleep(interval_timeout)
         timer_thread.cancel()
         self.assertEqual(self.counter, 3)
+
+    def test_wait_for_mq_startup(self):
+        self.assertTrue(wait_for_mq_startup("api.neon.ai", 5672))
+        self.assertFalse(wait_for_mq_startup("api.neon.ai", 443, 1))
 
     def setUp(self) -> None:
         self.counter = 0


### PR DESCRIPTION
Add method wait_for_mq_startup with unit test
Handle ConsumerThread init retry in case MQ server is starting up