### PR TITLE
Implement MQ client utils to resolve circular dependency with neon_utils

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Get Credential
         run: |
           mkdir -p ~/.local/share/neon
-          echo $CONNECTOR_CONFIG > ~/.local/share/neon/credentials.json
+          echo $CONNECTOR_CONFIG_DATA > ~/.local/share/neon/credentials.json
         shell: bash
         env:
-          CONNECTOR_CONFIG: ${{secrets.CONNECTOR_CONFIG}}
+          CONNECTOR_CONFIG_DATA: ${{secrets.CONNECTOR_CONFIG}}
       - name: Run Utils Tests
         run: |
           pytest tests/test_utils.py --doctest-modules --junitxml=tests/utils-test-results.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Get Credential
         run: |
           mkdir -p ~/.local/share/neon
-          echo $CONNECTOR_CONFIG_DATA > ~/.local/share/neon/credentials.json
+          echo $CONNECTOR_CONFIG > ~/.local/share/neon/credentials.json
         shell: bash
         env:
-          CONNECTOR_CONFIG_DATA: ${{secrets.CONNECTOR_CONFIG}}
+          CONNECTOR_CONFIG: ${{secrets.CONNECTOR_CONFIG}}
       - name: Run Utils Tests
         run: |
           pytest tests/test_utils.py --doctest-modules --junitxml=tests/utils-test-results.xml

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -155,7 +155,7 @@ class MQConnector(ABC):
                         "password": "<password of the service on mq server>"
                     }
                 },
-                "server": "<MQ Server IP>",
+                "server": "<MQ Server hostname or IP>",
                 "port": <MQ Server Port (default=5672)>,
                 "<self.property_key (default='properties')>": {
                     <key of the configurable property>:<value of the configurable property>

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -1,0 +1,141 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import uuid
+
+from threading import Event
+from pika.channel import Channel
+from pika.exceptions import ProbableAccessDeniedError, StreamLostError
+from neon_mq_connector.connector import MQConnector
+from ovos_config.config import Configuration
+
+from neon_utils.logger import LOG
+from neon_utils.socket_utils import b64_to_dict
+
+logging.getLogger("pika").setLevel(logging.CRITICAL)
+
+_default_mq_config = {
+    "server": "api.neon.ai",
+    "port": 5672,
+    "users": {
+        "mq_handler": {
+            "user": 'neon_api_utils',
+            "password": 'Klatchat2021'
+        }
+    }
+}
+
+
+class NeonMQHandler(MQConnector):
+    def __init__(self, config: dict, service_name: str, vhost: str):
+        super().__init__(config, service_name)
+        self.vhost = vhost
+        import pika
+        self.connection = pika.BlockingConnection(
+            parameters=self.get_connection_params(vhost))
+
+
+def send_mq_request(vhost: str, request_data: dict, target_queue: str,
+                    response_queue: str = None, timeout: int = 30,
+                    expect_response: bool = True) -> dict:
+    """
+    Sends a request to the MQ server and returns the response.
+    :param vhost: vhost to target
+    :param request_data: data to post to target_queue
+    :param target_queue: queue to post request to
+    :param response_queue: optional queue to monitor for a response.
+        Generally should be blank
+    :param timeout: time in seconds to wait for a response before timing out
+    :param expect_response: boolean indicating whether a response is expected
+    :return: response to request
+    """
+    response_queue = response_queue or uuid.uuid4().hex
+
+    response_event = Event()
+    message_id = None
+    response_data = dict()
+    config = dict()
+
+    def on_error(thread, error):
+        """
+        Override default error handler to suppress certain logged errors.
+        """
+        if isinstance(error, StreamLostError):
+            return
+        LOG.error(f"{thread} raised {error}")
+
+    def handle_mq_response(channel: Channel, method, _, body):
+        """
+            Method that handles Neon API output.
+            In case received output message with the desired id, event stops
+        """
+        api_output = b64_to_dict(body)
+        api_output_msg_id = api_output.get('message_id', None)
+        if api_output_msg_id == message_id:
+            LOG.debug(f'MQ output: {api_output}')
+            channel.basic_ack(delivery_tag=method.delivery_tag)
+            channel.close()
+            response_data.update(api_output)
+            response_event.set()
+        else:
+            channel.basic_nack(delivery_tag=method.delivery_tag)
+            LOG.debug(f"Ignoring {api_output_msg_id} waiting for {message_id}")
+
+    try:
+        config = dict(Configuration()).get('MQ') or _default_mq_config
+        neon_api_mq_handler = NeonMQHandler(config=config,
+                                            service_name='mq_handler',
+                                            vhost=vhost)
+        if not neon_api_mq_handler.connection.is_open:
+            raise ConnectionError("MQ Connection not established.")
+
+        if expect_response:
+            neon_api_mq_handler.register_consumer(
+                'neon_output_handler', neon_api_mq_handler.vhost,
+                response_queue, handle_mq_response, on_error, auto_ack=False)
+            neon_api_mq_handler.run_consumers()
+            request_data['routing_key'] = response_queue
+
+        message_id = neon_api_mq_handler.emit_mq_message(
+            connection=neon_api_mq_handler.connection, queue=target_queue,
+            request_data=request_data, exchange='')
+        LOG.debug(f'Sent request with keys: {request_data.keys()}')
+
+        if expect_response:
+            response_event.wait(timeout)
+            if not response_event.is_set():
+                LOG.error(f"Timeout waiting for response to: {message_id} on "
+                          f"{response_queue}")
+            neon_api_mq_handler.stop_consumers()
+    except ProbableAccessDeniedError:
+        raise ValueError(f"{vhost} is not a valid endpoint for "
+                         f"{config.get('users').get('mq_handler').get('user')}")
+    except Exception as ex:
+        LOG.error(f'Exception occurred while resolving Neon API: {ex}')
+    return response_data

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -53,7 +53,7 @@ def get_timeout(backoff_factor: float, number_of_retries: int) -> float:
 
 
 def retry(callback_on_exceeded: Union[str, Callable] = None, callback_on_attempt_failure: Union[str, Callable] = None,
-          num_retries: int = 3, backoff_factor: int = 5, use_self: bool = False,
+          num_retries: int = 3, backoff_factor: float = 5, use_self: bool = False,
           callback_on_attempt_failure_args: list = None, callback_on_exceeded_args: list = None):
     """
         Decorator for generic retrying function execution

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
 pika==1.2.0
-neon_utils[network]>=0.14,<2.0
+neon_utils[network]~=1.0

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -54,7 +54,6 @@ class MQConnectorChild(MQConnector):
         self._consume_event = None
         self._consumer_restarted_event = None
         self.observe_period = 10
-        self.vhost = '/neon_testing'
         self.register_consumer(name="error", vhost=self.vhost, queue="error",
                                callback=self.callback_func_error,
                                on_error=self.handle_error, auto_ack=False,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -43,6 +43,22 @@ from neon_mq_connector.utils.rabbit_utils import create_mq_callback
 
 
 class MQConnectorChild(MQConnector):
+    def __init__(self, config: dict, service_name: str):
+        super().__init__(config=config, service_name=service_name)
+        self.func_1_ok = False
+        self.func_2_ok = False
+        self.func_3_ok = False
+        self.func_3_knocks = 0
+        self.callback_ok = False
+        self.exception = None
+        self._consume_event = None
+        self._consumer_restarted_event = None
+        self.observe_period = 10
+        self.vhost = '/neon_testing'
+        self.register_consumer(name="error", vhost=self.vhost, queue="error",
+                               callback=self.callback_func_error,
+                               on_error=self.handle_error, auto_ack=False,
+                               restart_attempts=0)
 
     @create_mq_callback(include_callback_props=('channel', 'method',))
     def callback_func_1(self, channel, method):
@@ -96,20 +112,6 @@ class MQConnectorChild(MQConnector):
         super(MQConnectorChild, self).restart_consumer(name=name)
         if name == 'test3':
             self.consumer_restarted_event.set()
-
-    def __init__(self, config: dict, service_name: str):
-        super().__init__(config=config, service_name=service_name)
-        self.func_1_ok = False
-        self.func_2_ok = False
-        self.func_3_ok = False
-        self.func_3_knocks = 0
-        self.callback_ok = False
-        self.exception = None
-        self._consume_event = None
-        self._consumer_restarted_event = None
-        self.observe_period = 10
-        self.register_consumer(name="error", vhost=self.vhost, queue="error", callback=self.callback_func_error,
-                               on_error=self.handle_error, auto_ack=False, restart_attempts=0)
 
 
 class MQConnectorChildTest(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -129,7 +129,7 @@ class TestMQConnectorUtils(unittest.TestCase):
 
     def test_wait_for_mq_startup(self):
         self.assertTrue(wait_for_mq_startup("api.neon.ai", 5672))
-        self.assertFalse(wait_for_mq_startup("api.neon.ai", 443, 1))
+        self.assertFalse(wait_for_mq_startup("www.neon.ai", 5672, 1))
 
     def setUp(self) -> None:
         self.counter = 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,17 +30,47 @@ import os
 import sys
 import time
 import unittest
-import pytest
+import pika
+
+from threading import Thread
+from neon_utils.socket_utils import dict_to_b64, b64_to_dict
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from neon_mq_connector.utils import RepeatingTimer
 from neon_mq_connector.utils.connection_utils import get_timeout, retry, wait_for_mq_startup
+from neon_mq_connector.utils.client_utils import MQConnector
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+TEST_PATH = os.path.join(ROOT_DIR, "tests", "ccl_files")
+
+INPUT_CHANNEL = str(time.time())
+OUTPUT_CHANNEL = str(time.time())
 
 
 def callback_on_failure():
     """Simple callback on failure"""
     return False
+
+
+class TestMQConnector(MQConnector):
+    def __init__(self, config: dict, service_name: str, vhost: str):
+        super().__init__(config, service_name)
+        self.vhost = vhost
+
+    @staticmethod
+    def respond(channel, method, _, body):
+        request = b64_to_dict(body)
+        response = dict_to_b64({"message_id": request["message_id"],
+                                "success": True,
+                                "request_data": request["data"]})
+        reply_channel = request.get("routing_key") or OUTPUT_CHANNEL
+        channel.queue_declare(queue=reply_channel)
+        channel.basic_publish(exchange='',
+                              routing_key=reply_channel,
+                              body=response,
+                              properties=pika.BasicProperties(expiration='1000'))
+        channel.basic_ack(delivery_tag=method.delivery_tag)
 
 
 class TestMQConnectorUtils(unittest.TestCase):
@@ -51,7 +81,8 @@ class TestMQConnectorUtils(unittest.TestCase):
         """Simple method incrementing counter by one"""
         self.counter += 1
 
-    @retry(num_retries=3, backoff_factor=0.1, callback_on_exceeded=callback_on_failure, use_self=True)
+    @retry(num_retries=3, backoff_factor=0.1,
+           callback_on_exceeded=callback_on_failure, use_self=True)
     def method_passing_on_nth_attempt(self, num_attempts: int = 3) -> bool:
         """
             Simple method that is passing check only after n-th attempt
@@ -89,7 +120,8 @@ class TestMQConnectorUtils(unittest.TestCase):
     def test_repeating_timer(self):
         """Testing repeating timer thread"""
         interval_timeout = 3
-        timer_thread = RepeatingTimer(interval=0.9, function=self.repeating_method)
+        timer_thread = RepeatingTimer(interval=0.9,
+                                      function=self.repeating_method)
         timer_thread.start()
         time.sleep(interval_timeout)
         timer_thread.cancel()
@@ -101,3 +133,84 @@ class TestMQConnectorUtils(unittest.TestCase):
 
     def setUp(self) -> None:
         self.counter = 0
+
+
+class MqUtilTests(unittest.TestCase):
+    test_connector = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from neon_mq_connector.utils.client_utils import _default_mq_config
+        vhost = "/neon_testing"
+        cls.test_connector = TestMQConnector(config=_default_mq_config,
+                                             service_name="mq_handler",
+                                             vhost=vhost)
+        cls.test_connector.register_consumer("neon_utils_test", vhost,
+                                             INPUT_CHANNEL,
+                                             cls.test_connector.respond,
+                                             auto_ack=False)
+        cls.test_connector.run_consumers()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.test_connector.stop_consumers()
+
+    def test_send_mq_request_valid(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        request = {"data": time.time()}
+        response = send_mq_request("/neon_testing", request, INPUT_CHANNEL)
+        self.assertIsInstance(response, dict)
+        self.assertTrue(response["success"])
+        self.assertEqual(response["request_data"], request["data"])
+
+    def test_send_mq_request_spec_output_channel_valid(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        request = {"data": time.time()}
+        response = send_mq_request("/neon_testing", request,
+                                   INPUT_CHANNEL, OUTPUT_CHANNEL)
+        self.assertIsInstance(response, dict)
+        self.assertTrue(response["success"])
+        self.assertEqual(response["request_data"], request["data"])
+
+    def test_multiple_mq_requests(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        responses = dict()
+        processes = []
+
+        def check_response(name: str):
+            request = {"data": time.time()}
+            response = send_mq_request("/neon_testing", request, INPUT_CHANNEL)
+            self.assertIsInstance(response, dict)
+            if not isinstance(response, dict):
+                responses[name] = {'success': False,
+                                   'reason': 'Response is not a dict',
+                                   'response': response}
+                return
+            if not response.get("success"):
+                responses[name] = {'success': False,
+                                   'reason': 'Response success flag not true',
+                                   'response': response}
+                return
+            if response.get("request_data") != request["data"]:
+                responses[name] = {'success': False,
+                                   'reason': "Response data doesn't match request",
+                                   'response': response}
+                return
+            responses[name] = {'success': True}
+
+        for i in range(8):
+            p = Thread(target=check_response, args=(str(i),))
+            p.start()
+            processes.append(p)
+
+        for p in processes:
+            p.join(60)
+
+        self.assertEqual(len(processes), len(responses))
+        for resp in responses.values():
+            self.assertTrue(resp['success'], resp.get('reason'))
+
+    def test_send_mq_request_invalid_vhost(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        with self.assertRaises(ValueError):
+            send_mq_request("invalid_endpoint", {}, "test", "test", timeout=5)


### PR DESCRIPTION
This moves `neon_utils.mq_utils` to `neon_mq_connector.utils.client_utils` to remove a circular dependency. With this change,
`neon_utils` can specify `neon_mq_connector` as an optional dependency for backwards-compatibility only