### PR TITLE
Implement ovos-config and log deprecation for old config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 The Neon MQ Connector is an MQ interface for microservices.
 
 ## Configuration
+By default, this package will use [ovos-config](https://github.com/openvoiceos/ovos-config)
+to read default configuration. In general, configuration should be passed to the
+`MQConnector` object at init.
+
+### Legacy Configuration
 A global configuration for the MQ Connector may be specified at `~/.config/neon/mq_config.json`. This configuration file 
 may contain the following keys:
  - `server`: The hostname or IP address of the MQ server to connect to. If left blank, this defaults to `"localhost"`

--- a/neon_mq_connector/config.py
+++ b/neon_mq_connector/config.py
@@ -29,7 +29,9 @@
 import os
 import json
 from typing import Optional
-# TODO: Implement ovos-config
+from ovos_utils.log import LOG
+from ovos_config.config import Configuration as _Config
+from ovos_config.locations import get_xdg_config_save_path
 
 
 def load_neon_mq_config():
@@ -41,26 +43,25 @@ def load_neon_mq_config():
     """
     valid_config_paths = (
         os.path.expanduser(os.environ.get('NEON_MQ_CONFIG_PATH', "")),
-        os.path.join(os.path.expanduser(os.environ.get("NEON_CONFIG_PATH",
-                                                       "~/.config/neon")),
-                     "mq_config.json"),
+        os.path.join(get_xdg_config_save_path("neon"), "mq_config.json"),
         os.path.expanduser("~/.local/share/neon/credentials.json")
     )
     config = None
     for conf in valid_config_paths:
         if conf and os.path.isfile(conf):
-            config = Configuration().from_file(conf).config_data
+            LOG.warning(f"Legacy configuration found at {conf}")
+            with open(conf) as f:
+                config = json.load(f)
             break
     if not config:
-        return
-    if "MQ" in config.keys():
-        return config["MQ"]
-    else:
-        return config
+        config = _Config()
+    return config.get("MQ", config)
 
 
 class Configuration:
     def __init__(self, file_path: Optional[str] = None):
+        LOG.warning("This class is deprecated. "
+                    "Parse configuration files to dict or use `ovos_config`")
         self._config_data = dict()
         if file_path:
             self.from_file(file_path)

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -260,7 +260,7 @@ class MQConnector(ABC):
         Returns MQ Credentials object based on self.config values
         """
         if not self.service_config or self.service_config == dict():
-            raise Exception('Configuration is not set')
+            raise Exception(f'Configuration is not set for {self.service_name}')
         return pika.PlainCredentials(
             self.service_config.get('user', 'guest'),
             self.service_config.get('password', 'guest'))

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -109,7 +109,11 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
             LOG.debug(f"Ignoring {api_output_msg_id} waiting for {message_id}")
 
     try:
-        config = dict(Configuration()).get('MQ') or _default_mq_config
+        config = Configuration().get('MQ') or _default_mq_config
+        if not config['users'].get('mq_handler'):
+            LOG.warning("mq_handler not configured, using default credentials")
+            config['users']['mq_handler'] = \
+                _default_mq_config['users']['mq_handler']
         neon_api_mq_handler = NeonMQHandler(config=config,
                                             service_name='mq_handler',
                                             vhost=vhost)
@@ -138,5 +142,5 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
         raise ValueError(f"{vhost} is not a valid endpoint for "
                          f"{config.get('users').get('mq_handler').get('user')}")
     except Exception as ex:
-        LOG.error(f'Exception occurred while resolving Neon API: {ex}')
+        LOG.exception(f'Exception occurred while resolving Neon API: {ex}')
     return response_data

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -146,8 +146,10 @@ def wait_for_mq_startup(addr: str, port: int, timeout: int = 60) -> bool:
     :param timeout: Max seconds to wait for connection to come online
     """
     stop_time = time.time() + timeout
+    LOG.debug(f"Waiting for MQ server at {addr}:{port} to come online")
     while not check_port_is_open(addr, port):
-        LOG.debug("Waiting for MQ server to come online")
         if time.time() > stop_time:
+            LOG.warning(f"Timed out waiting after {timeout}s")
             return False
+    LOG.info("MQ Server Started")
     return True


### PR DESCRIPTION
# Description
Update `load_neon_mq_config` to fallback to ovos_config
Mark legacy `Configuration` class as deprecated
Log warning for legacy configuration files

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->