### PR TITLE
Update logging and response routing

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Run Connector Tests
         run: |
           pytest tests/test_connector.py --doctest-modules --junitxml=tests/connector-test-results.xml
-        env:
-          MQ_TESTING: 1
+#        env:
+#          MQ_TESTING: 1
       - name: Upload Connector test results
         uses: actions/upload-artifact@v2
         with:

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -418,8 +418,7 @@ class MQConnector(ABC):
                      exchange: Optional[str] = '',
                      queue: Optional[str] = '',
                      exchange_type: ExchangeType = ExchangeType.direct,
-                     expiration: int = 1000,
-                     override_message_id: bool = True) -> str:
+                     expiration: int = 1000) -> str:
         """
         Wrapper method for creation the MQ connection and immediate propagation
         of requested message with that

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -418,7 +418,8 @@ class MQConnector(ABC):
                      exchange: Optional[str] = '',
                      queue: Optional[str] = '',
                      exchange_type: ExchangeType = ExchangeType.direct,
-                     expiration: int = 1000) -> str:
+                     expiration: int = 1000,
+                     override_message_id: bool = True) -> str:
         """
         Wrapper method for creation the MQ connection and immediate propagation
         of requested message with that
@@ -432,6 +433,7 @@ class MQConnector(ABC):
         :param exchange_type: type of exchange to use
             (defaults to ExchangeType.direct)
         :param expiration: posted data expiration (in millis)
+        :param override_message_id: if True, generate a unique `message_id`
 
         :returns message_id: id of the propagated message
         """
@@ -452,12 +454,14 @@ class MQConnector(ABC):
             else:
                 LOG.debug(f'Sending {exchange_type} request to exchange '
                           f'{exchange}')
-                msg_id = self.emit_mq_message(mq_conn,
-                                              queue=queue,
-                                              request_data=request_data,
-                                              exchange=exchange,
-                                              exchange_type=exchange_type,
-                                              expiration=expiration)
+                msg_id = self.emit_mq_message(
+                    mq_conn,
+                    queue=queue,
+                    request_data=request_data,
+                    exchange=exchange,
+                    exchange_type=exchange_type,
+                    expiration=expiration,
+                    override_message_id=override_message_id)
         LOG.info(f'Message propagated, id={msg_id}')
         return msg_id
 

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -435,18 +435,19 @@ class MQConnector(ABC):
             vhost = self.vhost
         if not connection_props:
             connection_props = {}
-        LOG.debug(f'Opening connection on vhost={vhost}')
+        LOG.debug(f'Opening connection on vhost={vhost} queue={queue}')
         with self.create_mq_connection(vhost=vhost,
                                        **connection_props) as mq_conn:
             if exchange_type in (ExchangeType.fanout,
                                  ExchangeType.fanout.value,):
-                LOG.debug('Sending fanout request to MQ')
+                LOG.debug(f'Sending fanout request to exchange: {exchange}')
                 msg_id = self.publish_message(connection=mq_conn,
                                               request_data=request_data,
                                               exchange=exchange,
                                               expiration=expiration)
             else:
-                LOG.debug(f'Sending {exchange_type} request to MQ')
+                LOG.debug(f'Sending {exchange_type} request to exchange '
+                          f'{exchange}')
                 msg_id = self.emit_mq_message(mq_conn,
                                               queue=queue,
                                               request_data=request_data,
@@ -693,7 +694,7 @@ class MQConnector(ABC):
         Iteratively observes each consumer, and if it was launched but is not
         alive - restarts it
         """
-        LOG.debug('Observers state observation')
+        # LOG.debug('Observers state observation')
         consumers_dict = copy.copy(self.consumers)
         for consumer_name, consumer_instance in consumers_dict.items():
             if self.consumer_properties[consumer_name]['started'] and \

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -433,7 +433,6 @@ class MQConnector(ABC):
         :param exchange_type: type of exchange to use
             (defaults to ExchangeType.direct)
         :param expiration: posted data expiration (in millis)
-        :param override_message_id: if True, generate a unique `message_id`
 
         :returns message_id: id of the propagated message
         """
@@ -460,8 +459,7 @@ class MQConnector(ABC):
                     request_data=request_data,
                     exchange=exchange,
                     exchange_type=exchange_type,
-                    expiration=expiration,
-                    override_message_id=override_message_id)
+                    expiration=expiration)
         LOG.info(f'Message propagated, id={msg_id}')
         return msg_id
 

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -218,16 +218,16 @@ class MQConnector(ABC):
         self.service_configurable_properties()
         """
         return {
-                'sync_period': 10,  # in seconds
-                'observe_period': 20,  # in seconds
-                'vhost_prefix': '',  # Could be used for scalability purposes
-                'default_testing_prefix': 'test',
-                'testing_envs': (f'{self.service_name.upper()}_TESTING',
-                                 'MQ_TESTING',),  # order matters
-                'testing_prefix_envs': (f'{self.service_name.upper()}'
-                                        f'_TESTING_PREFIX',
-                                        'MQ_TESTING_PREFIX',)  # order matters
-                }
+            'sync_period': 10,  # in seconds
+            'observe_period': 20,  # in seconds
+            'vhost_prefix': '',  # Could be used for scalability purposes
+            'default_testing_prefix': 'test',
+            'testing_envs': (f'{self.service_name.upper()}_TESTING',
+                             'MQ_TESTING',),  # order matters
+            'testing_prefix_envs': (f'{self.service_name.upper()}'
+                                    f'_TESTING_PREFIX',
+                                    'MQ_TESTING_PREFIX',)  # order matters
+        }
 
     @property
     def service_configurable_properties(self) -> Dict[str, Any]:
@@ -453,13 +453,12 @@ class MQConnector(ABC):
             else:
                 LOG.debug(f'Sending {exchange_type} request to exchange '
                           f'{exchange}')
-                msg_id = self.emit_mq_message(
-                    mq_conn,
-                    queue=queue,
-                    request_data=request_data,
-                    exchange=exchange,
-                    exchange_type=exchange_type,
-                    expiration=expiration)
+                msg_id = self.emit_mq_message(mq_conn,
+                                              queue=queue,
+                                              request_data=request_data,
+                                              exchange=exchange,
+                                              exchange_type=exchange_type,
+                                              expiration=expiration)
         LOG.info(f'Message propagated, id={msg_id}')
         return msg_id
 

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -38,9 +38,6 @@ from ovos_utils.log import LOG
 
 from neon_mq_connector.utils.network_utils import b64_to_dict
 
-# TODO: Leave below to configuration
-logging.getLogger("pika").setLevel(logging.CRITICAL)
-
 _default_mq_config = {
     "server": "api.neon.ai",
     "port": 5672,
@@ -93,11 +90,19 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
 
     def handle_mq_response(channel: Channel, method, _, body):
         """
-            Method that handles Neon API output.
-            In case received output message with the desired id, event stops
+        Method that handles Neon API output.
+        In case received output message with the desired id, event stops
         """
         api_output = b64_to_dict(body)
-        api_output_msg_id = api_output.get('message_id', None)
+
+        # The Messagebus connector generates a unique `message_id` for each
+        # response message. Check context for the original one; otherwise,
+        # check in output directly as some APIs emit responses without a unique
+        # message_id
+        api_output_msg_id = \
+            api_output.get('context',
+                           api_output).get('mq', api_output).get('message_id')
+
         if api_output_msg_id == message_id:
             LOG.debug(f'MQ output: {api_output}')
             channel.basic_ack(delivery_tag=method.delivery_tag)

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -94,14 +94,7 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
         In case received output message with the desired id, event stops
         """
         api_output = b64_to_dict(body)
-
-        # The Messagebus connector generates a unique `message_id` for each
-        # response message. Check context for the original one; otherwise,
-        # check in output directly as some APIs emit responses without a unique
-        # message_id
-        api_output_msg_id = \
-            api_output.get('context',
-                           api_output).get('mq', api_output).get('message_id')
+        api_output_msg_id = api_output.get('message_id', None)
 
         if api_output_msg_id == message_id:
             LOG.debug(f'MQ output: {api_output}')

--- a/tests/test_backward_compatibility.py
+++ b/tests/test_backward_compatibility.py
@@ -42,7 +42,7 @@ class OldMQConnectorChild(MQConnector):
 
     def __init__(self, config: dict, service_name: str):
         super().__init__(config=config, service_name=service_name)
-        self.vhost = '/test'
+        self.vhost = '/neon_testing'
         self.func_1_ok = False
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -54,6 +54,7 @@ class MQConnectorChild(MQConnector):
         self.exception = None
         self._consume_event = None
         self._consumer_restarted_event = None
+        self._vhost = "/neon_testing"
         self.observe_period = 10
         self.register_consumer(name="error", vhost=self.vhost, queue="error",
                                callback=self.callback_func_error,


### PR DESCRIPTION
# Description
Cleanup logging to help troubleshoot responses
Handle `message_id` in context for `neon_mq_connector` response compat.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->