### PR TITLE
Add support for partial response messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ will be returned, the following requirements must be met:
 - Each response must be a dict with `_part` and `_is_final` keys.
 - `_part` is defined as a non-negative integer (the first response will specify `0`).
 - The final response must specify `_is_final=True`
-- The final response *MUST NOT* require the client to handle partial responses
+- The final response must be complete and *MUST NOT* require the client to handle partial responses
 
 ## Client Requests
 Most client applications will interact with services via `send_mq_request`. This
@@ -89,6 +89,9 @@ by `send_mq_request`. Keep in mind that the `timeout` param passed to
 `send_mq_request` applies to the full response, so the `timeout` value should
 reflect the longest time it will take for a final response to be generated, plus
 some margin.
+
+> Note: Responses may be received out of order, so the client is responsible 
+  for monitoring the `_part` and `_is_final` fields as needed
 
 ### Asynchronous Consumers
 By default, async-based consumers handling based on `pika.SelectConnection` will

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ is a `bytes` response (generally a `base64`-encoded `dict`).
 A callback function may choose to publish multiple response messages so the client
 may receive partial responses as they are being generated. If multiple responses
 will be returned, the following requirements must be met:
-- Each response must be a dict with `_part` and `_is_final` keys.
-- `_part` is defined as a non-negative integer (the first response will specify `0`).
-- The final response must specify `_is_final=True`
+- Each response must be a dict with `part` and `is_final` keys.
+- `part` is defined as a non-negative integer (the first response will specify `0`).
+- The final response must specify `is_final=True`
 - The final response must be complete and *MUST NOT* require the client to handle partial responses
 
 ## Client Requests
@@ -91,7 +91,7 @@ reflect the longest time it will take for a final response to be generated, plus
 some margin.
 
 > Note: Responses may be received out of order, so the client is responsible 
-  for monitoring the `_part` and `_is_final` fields as needed
+  for monitoring the `part` and `is_final` fields as needed
 
 ### Asynchronous Consumers
 By default, async-based consumers handling based on `pika.SelectConnection` will

--- a/README.md
+++ b/README.md
@@ -65,7 +65,28 @@ A response may be sent via:
                        properties=pika.BasicProperties(expiration='1000')
                        )
 ```
-Where `<queue>` is the queue to which the response will be published, and `data` is a `bytes` response (generally a `base64`-encoded `dict`).
+Where `<queue>` is the queue to which the response will be published, and `data`
+is a `bytes` response (generally a `base64`-encoded `dict`).
+
+#### Multi-part Responses
+A callback function may choose to publish multiple response messages so the client
+may receive partial responses as they are being generated. If multiple responses
+will be returned, the following requirements must be met:
+- Each response must be a dict with `_part` and `_is_final` keys.
+- The final response must specify `_is_final=True`
+- The final response *MUST NOT* require the client to handle partial responses
+
+## Client Requests
+Most client applications will interact with services via `send_mq_request`. This
+function will return a `dict` response to the input message.
+
+### Multi-part Responses
+A caller may optionally include a `stream_callback` argument which may receive
+partial responses if supported by the service generating the response. The
+`stream_callback` will always be called with the final result that is returned
+by `send_mq_request`. Keep in mind that the `timeout` param passed to 
+`send_mq_request` applies to the full response, so it may be desirable to increase
+the timeout if 
 
 ### Asynchronous Consumers
 By default, async-based consumers handling based on `pika.SelectConnection` will

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A callback function may choose to publish multiple response messages so the clie
 may receive partial responses as they are being generated. If multiple responses
 will be returned, the following requirements must be met:
 - Each response must be a dict with `_part` and `_is_final` keys.
+- `_part` is defined as a non-negative integer (the first response will specify `0`).
 - The final response must specify `_is_final=True`
 - The final response *MUST NOT* require the client to handle partial responses
 
@@ -85,8 +86,9 @@ A caller may optionally include a `stream_callback` argument which may receive
 partial responses if supported by the service generating the response. The
 `stream_callback` will always be called with the final result that is returned
 by `send_mq_request`. Keep in mind that the `timeout` param passed to 
-`send_mq_request` applies to the full response, so it may be desirable to increase
-the timeout if 
+`send_mq_request` applies to the full response, so the `timeout` value should
+reflect the longest time it will take for a final response to be generated, plus
+some margin.
 
 ### Asynchronous Consumers
 By default, async-based consumers handling based on `pika.SelectConnection` will

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -147,9 +147,9 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
             channel.basic_ack(delivery_tag=method.delivery_tag)
             if stream_callback:
                 stream_callback(api_output)
-            # `_is_final` defaults to True so a payload is always returned when
+            # `is_final` defaults to True so a payload is always returned when
             # the client stops waiting, including single-part responses.
-            if api_output.get('_is_final', True):
+            if api_output.get('is_final', True):
                 response_data.update(api_output)
                 channel.queue_delete(response_queue)
                 channel.close()

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -127,7 +127,7 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
         if api_output_msg_id == message_id:
             LOG.debug(f'MQ output: {api_output}')
             channel.basic_ack(delivery_tag=method.delivery_tag)
-            if api_output.get('_part'):
+            if isinstance(api_output.get('_part'), int):
                 # Handle multi-part responses
                 if stream_callback:
                     # Pass each part to the stream callback method if defined

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -89,10 +89,12 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
     :param response_queue: optional queue to monitor for a response.
         Generally should be blank
     :param timeout: time in seconds to wait for a complete response before
-        timing out. Note that in the event of a timeout, a partial response may
-        have been handled by `stream_callback`.
+        timing out. On timeout or malformed response, handlers are cleaned up
+        and an empty dict is returned. Note that in the event of a timeout, a
+        partial response may have been handled by `stream_callback`.
     :param expect_response: boolean indicating whether a response is expected
-    :param stream_callback: Optional function to pass partial responses to
+    :param stream_callback: Optional function called with each received response
+        when provided, including the final result returned by this function
     :return: response to request
     """
     response_queue = response_queue or uuid.uuid4().hex
@@ -100,6 +102,7 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
     response_event = Event()
     message_id = None
     response_data = dict()
+    response_error = None
     config = dict()
 
     def on_error(thread, error):
@@ -116,7 +119,20 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
         Method that handles Neon API output.
         In case received output message with the desired id, event stops
         """
-        api_output = b64_to_dict(body)
+        nonlocal response_error
+        try:
+            api_output = b64_to_dict(body)
+        except Exception as e:
+            LOG.exception(f"Malformed MQ response on {response_queue}")
+            response_error = e
+            try:
+                channel.basic_ack(delivery_tag=method.delivery_tag)
+                channel.queue_delete(response_queue)
+                channel.close()
+            except Exception:
+                LOG.exception("Failed to clean up after malformed MQ response")
+            response_event.set()
+            return
 
         # Backwards-compat. handles `context` in response for raw `Message`
         # objects sent across the MQ bus
@@ -129,17 +145,12 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
         if api_output_msg_id == message_id:
             LOG.debug(f'MQ output: {api_output}')
             channel.basic_ack(delivery_tag=method.delivery_tag)
-            if isinstance(api_output.get('_part'), int):
-                # Handle multi-part responses
-                if stream_callback:
-                    # Pass each part to the stream callback method if defined
-                    stream_callback(api_output)
-                if api_output.get('_is_final'):
-                    # Always return final result
-                    response_data.update(api_output)
-            else:
-                response_data.update(api_output)
+            if stream_callback:
+                stream_callback(api_output)
+            # `_is_final` defaults to True so a payload is always returned when
+            # the client stops waiting, including single-part responses.
             if api_output.get('_is_final', True):
+                response_data.update(api_output)
                 channel.queue_delete(response_queue)
                 channel.close()
                 response_event.set()
@@ -174,11 +185,14 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
 
         if expect_response:
             response_event.wait(timeout)
-            if not response_event.is_set():
-                LOG.error(f"Timeout waiting for response to: {message_id} on "
-                          f"{response_queue}")
             with SuppressPikaLogging():
                 neon_api_mq_handler.stop_consumers()
+            if response_error:
+                LOG.error(f"Malformed response to: {message_id} on "
+                          f"{response_queue}")
+            elif not response_event.is_set():
+                LOG.error(f"Timeout waiting for response to: {message_id} on "
+                          f"{response_queue}")
     except ProbableAccessDeniedError:
         raise ValueError(f"{vhost} is not a valid endpoint for "
                          f"{config.get('users').get('mq_handler').get('user')}")

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -130,7 +130,6 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
             LOG.debug(f'MQ output: {api_output}')
             channel.basic_ack(delivery_tag=method.delivery_tag)
             if isinstance(api_output.get('_part'), int):
-                # TODO: Consider forcing these to be passed to `stream_callback` synchronously
                 # Handle multi-part responses
                 if stream_callback:
                     # Pass each part to the stream callback method if defined

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -130,6 +130,7 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
             LOG.debug(f'MQ output: {api_output}')
             channel.basic_ack(delivery_tag=method.delivery_tag)
             if isinstance(api_output.get('_part'), int):
+                # TODO: Consider forcing these to be passed to `stream_callback` synchronously
                 # Handle multi-part responses
                 if stream_callback:
                     # Pass each part to the stream callback method if defined

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -29,6 +29,8 @@
 import uuid
 
 from threading import Event
+from typing import Callable, Optional
+
 from pika.channel import Channel
 from pika.spec import Basic, BasicProperties
 from pika.exceptions import ProbableAccessDeniedError, StreamLostError
@@ -77,7 +79,8 @@ class NeonMQHandler(MQConnector):
 
 def send_mq_request(vhost: str, request_data: dict, target_queue: str,
                     response_queue: str = None, timeout: int = 30,
-                    expect_response: bool = True) -> dict:
+                    expect_response: bool = True,
+                    stream_callback: Optional[Callable[[dict], None]] = None) -> dict:
     """
     Sends a request to the MQ server and returns the response.
     :param vhost: vhost to target
@@ -87,6 +90,7 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
         Generally should be blank
     :param timeout: time in seconds to wait for a response before timing out
     :param expect_response: boolean indicating whether a response is expected
+    :param stream_callback: Optional function to pass partial responses to
     :return: response to request
     """
     response_queue = response_queue or uuid.uuid4().hex
@@ -112,23 +116,31 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
         """
         api_output = b64_to_dict(body)
 
-        # The Messagebus connector generates a unique `message_id` for each
-        # response message. Check context for the original one; otherwise,
-        # check in output directly as some APIs emit responses without a unique
-        # message_id
+        # Backwards-compat. handles `context` in response for raw `Message`
+        # objects sent across the MQ bus
         api_output_msg_id = \
             api_output.get('context',
                            api_output).get('mq', api_output).get('message_id')
-        # TODO: One of these specs should be deprecated
         if api_output_msg_id != api_output.get('message_id'):
-            LOG.debug(f"Handling message_id from response context")
+            # TODO: `context.mq` handling should be deprecated
+            LOG.warning(f"Handling message_id from response context")
         if api_output_msg_id == message_id:
             LOG.debug(f'MQ output: {api_output}')
             channel.basic_ack(delivery_tag=method.delivery_tag)
-            channel.queue_delete(response_queue)
-            channel.close()
-            response_data.update(api_output)
-            response_event.set()
+            if api_output.get('_part'):
+                # Handle multi-part responses
+                if stream_callback:
+                    # Pass each part to the stream callback method if defined
+                    stream_callback(api_output)
+                if api_output.get('_is_final'):
+                    # Always return final result
+                    response_data.update(api_output)
+            else:
+                response_data.update(api_output)
+            if api_output.get('_is_final', True):
+                channel.queue_delete(response_queue)
+                channel.close()
+                response_event.set()
         else:
             channel.basic_nack(delivery_tag=method.delivery_tag)
             LOG.debug(f"Ignoring {api_output_msg_id} waiting for {message_id}")

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -88,7 +88,9 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
     :param target_queue: queue to post request to
     :param response_queue: optional queue to monitor for a response.
         Generally should be blank
-    :param timeout: time in seconds to wait for a response before timing out
+    :param timeout: time in seconds to wait for a complete response before
+        timing out. Note that in the event of a timeout, a partial response may
+        have been handled by `stream_callback`.
     :param expect_response: boolean indicating whether a response is expected
     :param stream_callback: Optional function to pass partial responses to
     :return: response to request

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,8 +146,8 @@ class SimpleMQConnector(MQConnector):
         for i in range(num_parts):
             response_text += f" {i}"
             response = {**base_response, **{"response": response_text,
-                                            "_part": i,
-                                            "_is_final": i == num_parts - 1}}
+                                            "part": i,
+                                            "is_final": i == num_parts - 1}}
             channel.basic_publish(exchange='',
                                   routing_key=reply_channel,
                                   body=dict_to_b64(response),
@@ -258,23 +258,23 @@ class TestClientUtils(unittest.TestCase):
                          stream_callback.call_args_list)
 
         parts = [call[0][0] for call in stream_callback.call_args_list]
-        # Completeness is defined by `_part`, not callback arrival order
-        parts_by_index = sorted(parts, key=lambda p: p["_part"])
-        self.assertEqual([p["_part"] for p in parts_by_index],
+        # Completeness is defined by `part`, not callback arrival order
+        parts_by_index = sorted(parts, key=lambda p: p["part"])
+        self.assertEqual([p["part"] for p in parts_by_index],
                          list(range(request["num_parts"])))
         for earlier, later in zip(parts_by_index, parts_by_index[1:]):
             self.assertTrue(later["response"].startswith(earlier["response"]),
                             (earlier["response"], later["response"]))
-            self.assertFalse(earlier.get("_is_final"))
-        self.assertTrue(parts_by_index[-1]["_is_final"])
+            self.assertFalse(earlier.get("is_final"))
+        self.assertTrue(parts_by_index[-1]["is_final"])
 
         self.assertIsInstance(response, dict, response)
         self.assertTrue(response.get("success"), response)
         self.assertEqual(response["request_data"], request["data"])
         self.assertEqual(len(response['response'].split()), request['num_parts'])
-        self.assertTrue(response['_is_final'])
+        self.assertTrue(response['is_final'])
 
-        final_callback = next(p for p in parts if p.get("_is_final"))
+        final_callback = next(p for p in parts if p.get("is_final"))
         self.assertEqual(response, final_callback)
 
     def test_multi_part_mq_response_without_stream_callback(self):
@@ -286,7 +286,7 @@ class TestClientUtils(unittest.TestCase):
         self.assertTrue(response.get("success"), response)
         self.assertEqual(response["request_data"], request["data"])
         self.assertEqual(len(response['response'].split()), request['num_parts'])
-        self.assertTrue(response['_is_final'])
+        self.assertTrue(response['is_final'])
 
     def test_send_mq_request_timeout_cleans_up(self):
         from neon_mq_connector.utils.client_utils import send_mq_request

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -235,6 +235,9 @@ class TestClientUtils(unittest.TestCase):
         self.assertEqual(len(response['response'].split()), request['num_parts'])
         self.assertTrue(response['_is_final'])
 
+        # Last callback is the same as the standard response
+        self.assertEqual(response, stream_callback.call_args[0][0])
+
     def test_multiple_mq_requests(self):
         from neon_mq_connector.utils.client_utils import send_mq_request
         responses = dict()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,6 +58,7 @@ RANDOM_STR = str(int(time.time()))
 INPUT_CHANNEL_A = RANDOM_STR + '_a'
 INPUT_CHANNEL_B = RANDOM_STR + '_b'
 INPUT_CHANNEL_MULTI = RANDOM_STR + '_multi'
+INPUT_CHANNEL_MALFORMED = RANDOM_STR + '_malformed'
 OUTPUT_CHANNEL = RANDOM_STR + '_output'
 
 TEST_DICT = {b"section 1": {"key1": "val1",
@@ -153,6 +154,17 @@ class SimpleMQConnector(MQConnector):
                                   properties=pika.BasicProperties(expiration='1000'))
         channel.basic_ack(delivery_tag=method.delivery_tag)
 
+    @staticmethod
+    def respond_malformed(channel, method, _, body):
+        request = b64_to_dict(body)
+        reply_channel = request.get("routing_key")
+        channel.queue_declare(queue=reply_channel)
+        channel.basic_publish(exchange='',
+                              routing_key=reply_channel,
+                              body=b'not-valid-b64',
+                              properties=pika.BasicProperties(expiration='1000'))
+        channel.basic_ack(delivery_tag=method.delivery_tag)
+
 
 @pytest.mark.usefixtures("rmq_instance")
 class TestClientUtils(unittest.TestCase):
@@ -186,6 +198,11 @@ class TestClientUtils(unittest.TestCase):
                                                   INPUT_CHANNEL_MULTI,
                                                   self.test_connector.respond_multiple,
                                                   auto_ack=False)
+            self.test_connector.register_consumer("neon_utils_test_malformed",
+                                                  vhost,
+                                                  INPUT_CHANNEL_MALFORMED,
+                                                  self.test_connector.respond_malformed,
+                                                  auto_ack=False)
             self.test_connector.run_consumers()
 
     @classmethod
@@ -200,6 +217,16 @@ class TestClientUtils(unittest.TestCase):
         self.assertIsInstance(response, dict)
         self.assertTrue(response["success"])
         self.assertEqual(response["request_data"], request["data"])
+
+        # Test with streaming callback
+        stream_callback = Mock()
+        response = send_mq_request("/neon_testing", request, INPUT_CHANNEL_A,
+                                   stream_callback=stream_callback)
+        self.assertIsInstance(response, dict)
+        self.assertTrue(response["success"])
+        self.assertEqual(response["request_data"], request["data"])
+        self.assertEqual(stream_callback.call_count, 1)
+        self.assertEqual(response, stream_callback.call_args[0][0])
 
     def test_send_mq_request_spec_output_channel_valid(self):
         from neon_mq_connector.utils.client_utils import send_mq_request
@@ -249,6 +276,35 @@ class TestClientUtils(unittest.TestCase):
 
         final_callback = next(p for p in parts if p.get("_is_final"))
         self.assertEqual(response, final_callback)
+
+    def test_multi_part_mq_response_without_stream_callback(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        request = {"data": time.time(),
+                   "num_parts": 5}
+        response = send_mq_request("/neon_testing", request, INPUT_CHANNEL_MULTI)
+        self.assertIsInstance(response, dict, response)
+        self.assertTrue(response.get("success"), response)
+        self.assertEqual(response["request_data"], request["data"])
+        self.assertEqual(len(response['response'].split()), request['num_parts'])
+        self.assertTrue(response['_is_final'])
+
+    def test_send_mq_request_timeout_cleans_up(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        response = send_mq_request("/neon_testing", {"data": time.time()},
+                                   f"{RANDOM_STR}_no_consumer", timeout=1)
+        self.assertEqual(response, {})
+        request = {"data": time.time()}
+        response = send_mq_request("/neon_testing", request, INPUT_CHANNEL_A)
+        self.assertTrue(response["success"])
+
+    def test_send_mq_request_malformed_response_cleans_up(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        response = send_mq_request("/neon_testing", {"data": time.time()},
+                                   INPUT_CHANNEL_MALFORMED, timeout=5)
+        self.assertEqual(response, {})
+        request = {"data": time.time()}
+        response = send_mq_request("/neon_testing", request, INPUT_CHANNEL_A)
+        self.assertTrue(response["success"])
 
     def test_multiple_mq_requests(self):
         from neon_mq_connector.utils.client_utils import send_mq_request

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,6 +131,26 @@ class SimpleMQConnector(MQConnector):
             "request_data": body["data"],
         }
 
+    @staticmethod
+    def respond_multiple(channel, method, _, body):
+        request = b64_to_dict(body)
+        num_parts = request.get("num_parts", 3)
+        base_response = {"message_id": request["message_id"],
+                         "success": True,
+                         "request_data": request["data"]}
+        reply_channel = request.get("routing_key")
+        channel.queue_declare(queue=reply_channel)
+        response_text = ""
+        for i in range(num_parts):
+            response_text += f" {i}"
+            response = {**base_response, **{"response": response_text,
+                                            "_part": i,
+                                            "_is_final": i == num_parts - 1}}
+            channel.basic_publish(exchange='',
+                                  routing_key=reply_channel,
+                                  body=dict_to_b64(response),
+                                  properties=pika.BasicProperties(expiration='1000'))
+        channel.basic_ack(delivery_tag=method.delivery_tag)
 
 
 @pytest.mark.usefixtures("rmq_instance")
@@ -159,6 +179,10 @@ class TestClientUtils(unittest.TestCase):
                                                   vhost,
                                                   INPUT_CHANNEL_B,
                                                   self.test_connector.respond_wrapped,
+            self.test_connector.register_consumer("neon_utils_test_multi",
+                                                  vhost,
+                                                  f"{INPUT_CHANNEL}-multi",
+                                                  self.test_connector.respond_multiple,
                                                   auto_ack=False)
             self.test_connector.run_consumers()
 
@@ -192,6 +216,24 @@ class TestClientUtils(unittest.TestCase):
         self.assertIsInstance(response, dict)
         self.assertTrue(response["success"])
         self.assertEqual(response["request_data"], request["data"])
+
+    def test_multi_part_mq_response(self):
+        from neon_mq_connector.utils.client_utils import send_mq_request
+        request = {"data": time.time(),
+                   "num_parts": 5}
+        target_queue = f"{INPUT_CHANNEL}-multi"
+        stream_callback = Mock()
+        response = send_mq_request("/neon_testing", request, target_queue,
+                                   stream_callback=stream_callback)
+
+        self.assertEqual(stream_callback.call_count, request['num_parts'],
+                         stream_callback.call_args_list)
+
+        self.assertIsInstance(response, dict, response)
+        self.assertTrue(response.get("success"), response)
+        self.assertEqual(response["request_data"], request["data"])
+        self.assertEqual(len(response['response'].split()), request['num_parts'])
+        self.assertTrue(response['_is_final'])
 
     def test_multiple_mq_requests(self):
         from neon_mq_connector.utils.client_utils import send_mq_request

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,6 +57,7 @@ RANDOM_STR = str(int(time.time()))
 
 INPUT_CHANNEL_A = RANDOM_STR + '_a'
 INPUT_CHANNEL_B = RANDOM_STR + '_b'
+INPUT_CHANNEL_MULTI = RANDOM_STR + '_multi'
 OUTPUT_CHANNEL = RANDOM_STR + '_output'
 
 TEST_DICT = {b"section 1": {"key1": "val1",
@@ -150,7 +151,6 @@ class SimpleMQConnector(MQConnector):
                                   routing_key=reply_channel,
                                   body=dict_to_b64(response),
                                   properties=pika.BasicProperties(expiration='1000'))
-            time.sleep(0.5)  # Used to ensure synchronous response handling
         channel.basic_ack(delivery_tag=method.delivery_tag)
 
 
@@ -180,9 +180,10 @@ class TestClientUtils(unittest.TestCase):
                                                   vhost,
                                                   INPUT_CHANNEL_B,
                                                   self.test_connector.respond_wrapped,
+                                                  auto_ack=False)
             self.test_connector.register_consumer("neon_utils_test_multi",
                                                   vhost,
-                                                  f"{INPUT_CHANNEL}-multi",
+                                                  INPUT_CHANNEL_MULTI,
                                                   self.test_connector.respond_multiple,
                                                   auto_ack=False)
             self.test_connector.run_consumers()
@@ -222,13 +223,23 @@ class TestClientUtils(unittest.TestCase):
         from neon_mq_connector.utils.client_utils import send_mq_request
         request = {"data": time.time(),
                    "num_parts": 5}
-        target_queue = f"{INPUT_CHANNEL}-multi"
         stream_callback = Mock()
-        response = send_mq_request("/neon_testing", request, target_queue,
+        response = send_mq_request("/neon_testing", request, INPUT_CHANNEL_MULTI,
                                    stream_callback=stream_callback)
 
         self.assertEqual(stream_callback.call_count, request['num_parts'],
                          stream_callback.call_args_list)
+
+        parts = [call[0][0] for call in stream_callback.call_args_list]
+        # Completeness is defined by `_part`, not callback arrival order
+        parts_by_index = sorted(parts, key=lambda p: p["_part"])
+        self.assertEqual([p["_part"] for p in parts_by_index],
+                         list(range(request["num_parts"])))
+        for earlier, later in zip(parts_by_index, parts_by_index[1:]):
+            self.assertTrue(later["response"].startswith(earlier["response"]),
+                            (earlier["response"], later["response"]))
+            self.assertFalse(earlier.get("_is_final"))
+        self.assertTrue(parts_by_index[-1]["_is_final"])
 
         self.assertIsInstance(response, dict, response)
         self.assertTrue(response.get("success"), response)
@@ -236,8 +247,8 @@ class TestClientUtils(unittest.TestCase):
         self.assertEqual(len(response['response'].split()), request['num_parts'])
         self.assertTrue(response['_is_final'])
 
-        # Last callback is the same as the standard response
-        self.assertEqual(response, stream_callback.call_args[0][0])
+        final_callback = next(p for p in parts if p.get("_is_final"))
+        self.assertEqual(response, final_callback)
 
     def test_multiple_mq_requests(self):
         from neon_mq_connector.utils.client_utils import send_mq_request

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -150,6 +150,7 @@ class SimpleMQConnector(MQConnector):
                                   routing_key=reply_channel,
                                   body=dict_to_b64(response),
                                   properties=pika.BasicProperties(expiration='1000'))
+            time.sleep(0.5)  # Used to ensure synchronous response handling
         channel.basic_ack(delivery_tag=method.delivery_tag)
 
 


### PR DESCRIPTION
# Description
Adds support for multi-part responses in `send_mq_request`
Adds an optional callback parameter to handle partial responses

# Issues
- Needs to be rebased on `dev` after merge of https://github.com/NeonGeckoCom/neon_mq_connector/pull/104

# Other Notes
- The API for responses is defined in https://github.com/NeonGeckoCom/neon-data-models/pull/7
- Specifies that the "final" message always contain the full response
- The primary motivation here is supporting streaming LLM responses, but the implementation should be flexible for other applications
- This makes `part` and `is_final` reserved keys, like `message_id`