### PR TITLE
Update tests to use temporary RMQ instance and improve coverage

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           pip install . -r requirements/test_requirements.txt
       - name: Run Backward Compatibility Tests
         run: |
-          pytest tests/test_backward_compatibility.py --doctest-modules --junitxml=tests/backward-compatibility-test-results.xml
+          pytest tests/backward_compat_tests.py --doctest-modules --junitxml=tests/backward-compatibility-test-results.xml
       - name: Upload Backward Compatibility test results
         uses: actions/upload-artifact@v4
         with:
@@ -50,19 +50,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install . -r requirements/test_requirements.txt
-      - name: Run Utils Tests
+
+      - name: Run Unit Tests
         run: |
-          pytest tests/test_utils.py --doctest-modules --junitxml=tests/utils-test-results.xml
-      - name: Upload Utils test results
+          pytest tests --doctest-modules --junitxml=tests/test-results.xml
+      - name: Upload test results
         uses: actions/upload-artifact@v4
         with:
-          name: utils-test-results-${{ matrix.python-version }}
-          path: tests/utils-test-results.xml
-      - name: Run Connector Tests
-        run: |
-          pytest tests/test_connector.py --doctest-modules --junitxml=tests/connector-test-results.xml
-      - name: Upload Connector test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: connector-test-results-${{ matrix.python-version }}
-          path: tests/connector-test-results.xml
+          name: test-results-${{ matrix.python-version }}
+          path: tests/test-results.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -66,11 +66,3 @@ jobs:
         with:
           name: connector-test-results-${{ matrix.python-version }}
           path: tests/connector-test-results.xml
-      - name: Run Backward Compatibility Tests
-        run: |
-          pytest tests/test_backward_compatibility.py --doctest-modules --junitxml=tests/backward-compatibility-test-results.xml
-      - name: Upload Backward Compatibility test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: backward-compatibility-test-results-${{ matrix.python-version }}
-          path: tests/backward-compatibility-test-results.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,19 +4,48 @@ on:
   workflow_dispatch:
 
 jobs:
+  backwards_compat_tests:
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.10']
+      max-parallel: 1
+      timeout-minutes: 30
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - name: Set up python ${{ matrix.python-version }}
+          uses: actions/setup-python@v5
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install . -r requirements/test_requirements.txt
+        - name: Run Backward Compatibility Tests
+          run: |
+            pytest tests/test_backward_compatibility.py --doctest-modules --junitxml=tests/backward-compatibility-test-results.xml
+        - name: Upload Backward Compatibility test results
+          uses: actions/upload-artifact@v4
+          with:
+            name: backward-compatibility-test-results-${{ matrix.python-version }}
+            path: tests/backward-compatibility-test-results.xml
   unit_tests:
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
-      max-parallel: 1
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install apt dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y rabbitmq-server
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: backward-compatibility-test-results-${{ matrix.python-version }}
           path: tests/backward-compatibility-test-results.xml
-unit_tests:
+  unit_tests:
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,27 +9,27 @@ jobs:
       matrix:
         python-version: [ '3.8', '3.10']
       max-parallel: 1
-      timeout-minutes: 30
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - name: Set up python ${{ matrix.python-version }}
-          uses: actions/setup-python@v5
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install . -r requirements/test_requirements.txt
-        - name: Run Backward Compatibility Tests
-          run: |
-            pytest tests/test_backward_compatibility.py --doctest-modules --junitxml=tests/backward-compatibility-test-results.xml
-        - name: Upload Backward Compatibility test results
-          uses: actions/upload-artifact@v4
-          with:
-            name: backward-compatibility-test-results-${{ matrix.python-version }}
-            path: tests/backward-compatibility-test-results.xml
-  unit_tests:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . -r requirements/test_requirements.txt
+      - name: Run Backward Compatibility Tests
+        run: |
+          pytest tests/test_backward_compatibility.py --doctest-modules --junitxml=tests/backward-compatibility-test-results.xml
+      - name: Upload Backward Compatibility test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: backward-compatibility-test-results-${{ matrix.python-version }}
+          path: tests/backward-compatibility-test-results.xml
+unit_tests:
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]

--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -146,8 +146,6 @@ class BlockingConsumerThread(threading.Thread):
 
     def _close_connection(self):
         try:
-            if self.is_consuming:
-                self.channel.stop_consuming()
             if self.connection and self.connection.is_open:
                 self.connection.close()
         except pika.exceptions.StreamLostError:

--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -44,7 +44,8 @@ class BlockingConsumerThread(threading.Thread):
 
     # retry to handle connection failures in case MQ server is still starting
     def __init__(self, connection_params: pika.ConnectionParameters,
-                 queue: str, callback_func: callable,
+                 queue: str,
+                 callback_func: callable,
                  error_func: callable = consumer_utils.default_error_handler,
                  auto_ack: bool = True,
                  queue_reset: bool = False,
@@ -71,7 +72,8 @@ class BlockingConsumerThread(threading.Thread):
             to learn more about different exchanges
         """
         threading.Thread.__init__(self, *args, **kwargs)
-        self._is_consuming = False  # annotates that ConsumerThread is running
+        self._consumer_started = threading.Event()  # annotates that ConsumerThread is running
+        self._consumer_started.clear()
         self._is_consumer_alive = True  # annotates that ConsumerThread is alive and shall be recreated
 
         self.callback_func = callback_func
@@ -96,15 +98,15 @@ class BlockingConsumerThread(threading.Thread):
 
     @property
     def is_consuming(self) -> bool:
-        return self._is_consuming
+        return self._consumer_started.is_set()
 
     def run(self):
         """Creating consumer channel"""
-        if not self._is_consuming:
+        if not self.is_consuming:
             try:
                 super(BlockingConsumerThread, self).run()
                 self._create_connection()
-                self._is_consuming = True
+                self._consumer_started.set()
                 self.channel.start_consuming()
             except Exception as e:
                 self._close_connection()
@@ -144,11 +146,13 @@ class BlockingConsumerThread(threading.Thread):
 
     def _close_connection(self):
         try:
+            if self.is_consuming:
+                self.channel.stop_consuming()
             if self.connection and self.connection.is_open:
                 self.connection.close()
         except pika.exceptions.StreamLostError:
             pass
         except Exception as e:
             LOG.exception(f"Failed to close connection due to unexpected exception: {e}")
-        self._is_consuming = False
+        self._consumer_started.clear()
         self._is_consumer_alive = False

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -217,7 +217,8 @@ class SelectConsumerThread(threading.Thread):
                 self.connection.close()
                 LOG.info(f"Waiting for channel close")
                 if not self._channel_closed.wait(15):
-                    raise TimeoutError(f"Timeout waiting for channel close. closed={self.channel.is_closed}")
+                    raise TimeoutError(f"Timeout waiting for channel close. "
+                                       f"is_closed={self.channel.is_closed}")
                 LOG.info(f"Channel closed")
             if self.connection:
                 self.connection.ioloop.stop()
@@ -242,6 +243,6 @@ class SelectConsumerThread(threading.Thread):
             self._close_connection(mark_consumer_as_dead=True)
         LOG.info(f"Stopped consumer. Waiting up to {timeout}s for thread to terminate.")
         try:
-            threading.Thread.join(self, timeout=timeout)
+            super().join(timeout=timeout)
         except Exception as e:
             LOG.exception(e)

--- a/neon_mq_connector/utils/consumer_utils.py
+++ b/neon_mq_connector/utils/consumer_utils.py
@@ -29,6 +29,7 @@
 
 from ovos_utils.log import LOG
 
+
 def default_error_handler(*args):
     """
     Default handler for Consumer instances

--- a/neon_mq_connector/utils/rabbit_utils.py
+++ b/neon_mq_connector/utils/rabbit_utils.py
@@ -26,9 +26,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import inspect
-from inspect import ismethod
-from functools import wraps
 
+from functools import wraps
 from ovos_utils.log import LOG
 
 from neon_mq_connector.utils.network_utils import b64_to_dict
@@ -36,7 +35,12 @@ from neon_mq_connector.utils.network_utils import b64_to_dict
 
 def create_mq_callback(include_callback_props: tuple = ('body',)):
     """
-    Creates MQ callback method by filtering relevant MQ attributes
+    Creates MQ callback method by filtering relevant MQ attributes. Use this
+    decorator to simplify creation of MQ callbacks.
+
+    Note that the consumer must have `auto_ack=True` specified at registration
+    if the decorated function does not accept `channel` and `method` kwargs that
+    are required to acknowledge a message.
     """
 
     if not include_callback_props:

--- a/neon_mq_connector/utils/rabbit_utils.py
+++ b/neon_mq_connector/utils/rabbit_utils.py
@@ -25,7 +25,8 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+import inspect
+from inspect import ismethod
 from functools import wraps
 
 from ovos_utils.log import LOG
@@ -34,17 +35,16 @@ from neon_mq_connector.utils.network_utils import b64_to_dict
 
 
 def create_mq_callback(include_callback_props: tuple = ('body',)):
-    """ Creates MQ callback method by filtering relevant MQ attributes """
+    """
+    Creates MQ callback method by filtering relevant MQ attributes
+    """
 
     if not include_callback_props:
         include_callback_props = ()
 
     def wrapper(f):
-
-        @wraps(f)
-        def wrapped(self, *f_args):
+        def _parse_kwargs(*f_args) -> dict:
             mq_props = ['channel', 'method', 'properties', 'body']
-
             callback_kwargs = {}
 
             for idx in range(len(mq_props)):
@@ -54,19 +54,39 @@ def create_mq_callback(include_callback_props: tuple = ('body',)):
                         if value and isinstance(value, bytes):
                             dict_data = b64_to_dict(value)
                             callback_kwargs['body'] = dict_data
+                        elif value and isinstance(value, dict):
+                            callback_kwargs['body'] = value
                         else:
                             raise TypeError(f'Invalid body received, expected: '
                                             f'bytes string; got: {type(value)}')
                     else:
                         callback_kwargs[mq_props[idx]] = value
+            return callback_kwargs
+
+        @wraps(f)
+        def wrapped_classmethod(self, *f_args):
             try:
-                res = f(self, **callback_kwargs)
+                res = f(self, **_parse_kwargs(*f_args))
             except Exception as ex:
                 LOG.error(f'Execution of {f.__name__} failed due to '
                           f'exception={ex}')
                 res = None
             return res
 
+        @wraps(f)
+        def wrapped(*f_args):
+            try:
+                res = f(**_parse_kwargs(*f_args))
+            except Exception as ex:
+                LOG.error(f'Execution of {f.__name__} failed due to '
+                          f'exception={ex}')
+                res = None
+            return res
+
+        # Use the appropriate wrapper for a class method vs a function
+        signature = inspect.signature(f).parameters
+        if 'self' in signature:
+            return wrapped_classmethod
         return wrapped
 
     return wrapper

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,2 +1,3 @@
-pytest~=6.2
+pytest~=8.0
 parameterized~=0.9.0
+pytest-rabbitmq~=3.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,27 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/backward_compat_tests.py
+++ b/tests/backward_compat_tests.py
@@ -33,7 +33,6 @@ from parameterized import parameterized
 
 from neon_mq_connector import MQConnector
 from neon_mq_connector.config import Configuration
-from neon_mq_connector.connector import ConsumerThreadInstance
 from neon_mq_connector.consumers import SelectConsumerThread, BlockingConsumerThread
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,81 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+
+from port_for import get_port
+from pytest_rabbitmq.factories.executor import RabbitMqExecutor
+from pytest_rabbitmq.factories.process import get_config
+
+
+@pytest.fixture(scope="class")
+def rmq_instance(request, tmp_path_factory):
+    config = get_config(request)
+    rabbit_ctl = config["ctl"]
+    rabbit_server = config["server"]
+    rabbit_host = "127.0.0.1"
+    rabbit_port = get_port(config["port"])
+    rabbit_distribution_port = get_port(
+        config["distribution_port"], [rabbit_port]
+    )
+    assert rabbit_distribution_port
+    assert (
+            rabbit_distribution_port != rabbit_port
+    ), "rabbit_port and distribution_port can not be the same!"
+
+    tmpdir = tmp_path_factory.mktemp(f"pytest-rabbitmq-{request.fixturename}")
+
+    rabbit_plugin_path = config["plugindir"]
+
+    rabbit_logpath = config["logsdir"]
+
+    if not rabbit_logpath:
+        rabbit_logpath = tmpdir / "logs"
+
+    rabbit_executor = RabbitMqExecutor(
+        rabbit_server,
+        rabbit_host,
+        rabbit_port,
+        rabbit_distribution_port,
+        rabbit_ctl,
+        logpath=rabbit_logpath,
+        path=tmpdir,
+        plugin_path=rabbit_plugin_path,
+        node_name=config["node"],
+    )
+
+    rabbit_executor.start()
+
+    # Init RMQ config
+    rabbit_executor.rabbitctl_output("add_user", "test_user",
+                                     "test_password")
+    rabbit_executor.rabbitctl_output("add_vhost", "/neon_testing")
+    rabbit_executor.rabbitctl_output("set_permissions", "-p",
+                                     "/neon_testing", "test_user", ".*", ".*",
+                                     ".*")
+    request.cls.rmq_instance = rabbit_executor

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -292,12 +292,12 @@ class MQConnectorChildTest(unittest.TestCase):
         self.connector_instance.publish_message = real_method
 
 
+@pytest.mark.usefixtures("rmq_instance")
 class MQConnectorChildAsyncModeTest(MQConnectorChildTest):
 
-    @classmethod
-    def setUpClass(cls):
-        super(MQConnectorChildAsyncModeTest, cls).setUpClass()
-        cls.connector_instance.async_consumers_enabled = True
+    def setUp(self):
+        MQConnectorChildTest.setUp(self)
+        self.connector_instance.async_consumers_enabled = True
 
 
 class TestMQConnectorInit(unittest.TestCase):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2022 Neongecko.com Inc.
+# Copyright 2008-2024 Neongecko.com Inc.
 # Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
 # Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
 # BSD-3 License
@@ -25,7 +25,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import os
+
 import threading
 import time
 import unittest
@@ -36,10 +36,11 @@ from unittest.mock import Mock
 from ovos_utils.log import LOG
 from pika.exchange_type import ExchangeType
 
-from neon_mq_connector.config import Configuration
 from neon_mq_connector.connector import MQConnector, ConsumerThreadInstance
 from neon_mq_connector.utils import RepeatingTimer
 from neon_mq_connector.utils.rabbit_utils import create_mq_callback
+
+from .fixtures import rmq_instance
 
 
 class MQConnectorChild(MQConnector):
@@ -110,19 +111,28 @@ class MQConnectorChild(MQConnector):
             self.consumer_restarted_event.set()
 
 
+@pytest.mark.usefixtures("rmq_instance")
 class MQConnectorChildTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        file_path = os.path.join(os.path.dirname(__file__), "test_config.json")
-        cls.connector_instance = MQConnectorChild(
-            config=Configuration(file_path=file_path).config_data,
-            service_name='test')
-        cls.connector_instance.run(run_sync=False)
+    connector_instance = None
+
+    def setUp(self):
+        if self.connector_instance is None:
+            self.connector_instance = MQConnectorChild(
+                config={"server": "127.0.0.1",
+                        "port": self.rmq_instance.port,
+                        "users": {
+                            "test": {
+                                "user": "test_user",
+                                "password": "test_password"
+                            }}},
+                service_name='test')
+            self.connector_instance.run(run_sync=False)
 
     @classmethod
     def tearDownClass(cls) -> None:
         try:
-            cls.connector_instance.stop()
+            if cls.connector_instance is not None:
+                cls.connector_instance.stop()
         except ChildProcessError as e:
             LOG.error(e)
 
@@ -143,13 +153,13 @@ class MQConnectorChildTest(unittest.TestCase):
                                                   exchange='',
                                                   queue='test',
                                                   callback=self.connector_instance.callback_func_1,
-                                                  auto_ack=False,)
+                                                  auto_ack=False, )
         self.connector_instance.register_consumer(name="test2",
                                                   vhost=self.connector_instance.vhost,
                                                   exchange='',
                                                   queue='test1',
                                                   callback=self.connector_instance.callback_func_2,
-                                                  auto_ack=False,)
+                                                  auto_ack=False, )
 
         self.connector_instance.run_consumers(names=test_consumers)
 
@@ -176,11 +186,11 @@ class MQConnectorChildTest(unittest.TestCase):
                                                     exchange='test',
                                                     # exchange_reset=True,
                                                     callback=self.connector_instance.callback_func_1,
-                                                    auto_ack=False,)
+                                                    auto_ack=False, )
         self.connector_instance.register_subscriber(name="test2", vhost=self.connector_instance.vhost,
                                                     exchange='test',
                                                     callback=self.connector_instance.callback_func_2,
-                                                    auto_ack=False,)
+                                                    auto_ack=False, )
 
         self.connector_instance.run_consumers(names=test_consumers)
         time.sleep(0.5)
@@ -196,7 +206,7 @@ class MQConnectorChildTest(unittest.TestCase):
         self.assertTrue(self.connector_instance.func_2_ok)
 
     @pytest.mark.timeout(30)
-    def test_error(self,):
+    def test_error(self, ):
         self.connector_instance.register_consumer(
             name="error",
             vhost=self.connector_instance.vhost,
@@ -220,7 +230,7 @@ class MQConnectorChildTest(unittest.TestCase):
         self.assertEqual(str(self.connector_instance.exception), "Exception to Handle")
 
     @pytest.mark.timeout(30)
-    def test_consumer_after_message(self,):
+    def test_consumer_after_message(self, ):
 
         self.connector_instance.send_message(queue='test3',
                                              request_data={'data': 'test'},
@@ -230,7 +240,7 @@ class MQConnectorChildTest(unittest.TestCase):
                                                   vhost=self.connector_instance.vhost,
                                                   queue="test3",
                                                   callback=self.connector_instance.callback_func_after_message,
-                                                  auto_ack=False,)
+                                                  auto_ack=False, )
 
         self.connector_instance.run_consumers(names=("test_consumer_after_message",))
 
@@ -239,7 +249,7 @@ class MQConnectorChildTest(unittest.TestCase):
         self.assertTrue(self.connector_instance.callback_ok)
 
     @pytest.mark.timeout(30)
-    def test_consumer_restarted(self,):
+    def test_consumer_restarted(self, ):
         self.connector_instance.register_consumer(
             name="test3",
             vhost=self.connector_instance.vhost,

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -25,6 +25,8 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import asyncio
+from time import sleep
 from unittest.mock import Mock
 
 import pytest
@@ -96,5 +98,73 @@ class TestBlockingConsumer(TestCase):
 
 @pytest.mark.usefixtures("rmq_instance")
 class TestSelectConsumer(TestCase):
-    from neon_mq_connector.consumers.select_consumer import SelectConsumerThread
-    # TODO
+    def test_select_consumer_thread(self):
+        from neon_mq_connector.consumers.select_consumer import SelectConsumerThread
+        connection_params = ConnectionParameters(host='localhost',
+                                                 port=self.rmq_instance.port,
+                                                 virtual_host="/neon_testing",
+                                                 credentials=PlainCredentials(
+                                                     "test_user",
+                                                     "test_password"))
+        queue = "test_q"
+        callback = Mock()
+        error = Mock()
+
+        # Valid thread
+        test_thread = SelectConsumerThread(connection_params, queue, callback,
+                                           error)
+        test_thread.on_connected = Mock(side_effect=test_thread.on_connected)
+        test_thread.on_channel_open = Mock(side_effect=test_thread.on_channel_open)
+        test_thread.on_close = Mock(side_effect=test_thread.on_close)
+        self.assertEqual(test_thread.callback_func, callback)
+        self.assertEqual(test_thread.error_func, error)
+        self.assertIsInstance(test_thread.auto_ack, bool)
+        self.assertIsInstance(test_thread.exchange, str)
+        self.assertIsInstance(test_thread.exchange_type, ExchangeType)
+        self.assertIsInstance(test_thread.exchange_reset, bool)
+        self.assertEqual(test_thread.queue, queue)
+        self.assertIsInstance(test_thread.queue_reset, bool)
+        self.assertIsInstance(test_thread.queue_exclusive, bool)
+        self.assertEqual(test_thread.connection_params, connection_params)
+
+        self.assertTrue(test_thread.is_consumer_alive)
+        self.assertFalse(test_thread.is_consuming)
+
+        test_thread.start()
+        while not test_thread.is_consuming:
+            sleep(0.1)
+        # asyncio.run(test_thread._consumer_started.wait())
+        test_thread.on_connected.assert_called_once()
+        test_thread.on_channel_open.assert_called_once()
+        # TODO: Test call args
+        self.assertTrue(test_thread.is_consuming)
+        self.assertTrue(test_thread.channel.is_open)
+
+        test_thread.join(30)
+        self.assertFalse(test_thread.is_consuming)
+        self.assertTrue(test_thread.channel.is_closed or
+                        test_thread.channel.is_closing)
+        self.assertFalse(test_thread.is_consumer_alive)
+        self.assertTrue(test_thread.channel.is_closed)
+        test_thread.on_close.assert_called_once()
+
+        # Invalid thread connection
+        connection_params.port = 80
+        test_thread = SelectConsumerThread(connection_params, queue, callback,
+                                           error)
+        test_thread.on_connected = Mock(side_effect=test_thread.on_connected)
+        test_thread.on_channel_open = Mock(side_effect=test_thread.on_channel_open)
+        test_thread.on_connection_fail = Mock(side_effect=test_thread.on_connection_fail)
+        test_thread.on_close = Mock(side_effect=test_thread.on_close)
+        test_thread.max_connection_failed_attempts = 0
+        test_thread.start()
+        sleep(1)  # TODO: Better callback method
+        self.assertFalse(test_thread.is_consuming)
+        self.assertIsNone(test_thread.channel)
+        test_thread.on_connection_fail.assert_called_once()
+        test_thread.error_func.assert_called_once_with("Connection not established")
+
+        test_thread.join(30)
+        self.assertFalse(test_thread.is_consuming)
+        self.assertFalse(test_thread.is_consumer_alive)
+        test_thread.on_close.assert_not_called()

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,0 +1,100 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2024 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from unittest.mock import Mock
+
+import pytest
+
+from unittest import TestCase
+
+from pika.connection import ConnectionParameters
+from pika.credentials import PlainCredentials
+from pika.exchange_type import ExchangeType
+
+from .fixtures import rmq_instance
+
+
+@pytest.mark.usefixtures("rmq_instance")
+class TestBlockingConsumer(TestCase):
+
+    def test_blocking_consumer_thread(self):
+        from neon_mq_connector.consumers.blocking_consumer import BlockingConsumerThread
+        connection_params = ConnectionParameters(host='localhost',
+                                                 port=self.rmq_instance.port,
+                                                 virtual_host="/neon_testing",
+                                                 credentials=PlainCredentials(
+                                                     "test_user",
+                                                     "test_password"))
+        queue = "test_q"
+        callback = Mock()
+        error = Mock()
+
+        # Valid thread
+        test_thread = BlockingConsumerThread(connection_params, queue, callback,
+                                             error)
+        self.assertEqual(test_thread.callback_func, callback)
+        self.assertEqual(test_thread.error_func, error)
+        self.assertIsInstance(test_thread.auto_ack, bool)
+        self.assertIsInstance(test_thread.exchange, str)
+        self.assertIsInstance(test_thread.exchange_type, ExchangeType)
+        self.assertIsInstance(test_thread.exchange_reset, bool)
+        self.assertEqual(test_thread.queue, queue)
+        self.assertIsInstance(test_thread.queue_reset, bool)
+        self.assertIsInstance(test_thread.queue_exclusive, bool)
+        self.assertEqual(test_thread.connection_params, connection_params)
+
+        self.assertTrue(test_thread.is_consumer_alive)
+        self.assertFalse(test_thread.is_consuming)
+
+        test_thread.start()
+        test_thread._consumer_started.wait(5)
+        self.assertTrue(test_thread.is_consuming)
+        self.assertTrue(test_thread.channel.is_open)
+
+        test_thread.join(30)
+        self.assertFalse(test_thread.is_consuming)
+        self.assertTrue(test_thread.channel.is_closed)
+        self.assertFalse(test_thread.is_consumer_alive)
+
+        # Invalid thread connection
+        connection_params.port = 80
+        test_thread = BlockingConsumerThread(connection_params, queue, callback,
+                                             error)
+        test_thread.start()
+        test_thread._consumer_started.wait(5)
+        self.assertFalse(test_thread.is_consuming)
+        self.assertIsNone(test_thread.channel)
+
+        test_thread.join(30)
+        self.assertFalse(test_thread.is_consuming)
+        self.assertFalse(test_thread.is_consumer_alive)
+
+
+@pytest.mark.usefixtures("rmq_instance")
+class TestSelectConsumer(TestCase):
+    from neon_mq_connector.consumers.select_consumer import SelectConsumerThread
+    # TODO

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -235,11 +235,13 @@ class TestMQConnectionUtils(unittest.TestCase):
         self.assertEqual(timeout, 0.4)
 
     def test_retry(self):
-        """Testing retry decorator"""
+        # Retry with successful outcome
         outcome = self.method_passing_on_nth_attempt(num_attempts=3)
         self.assertTrue(outcome)
         self.assertEqual(2, self.counter)
 
+        # Retry with failing outcome
+        self.counter = 0
         outcome = self.method_passing_on_nth_attempt(num_attempts=4)
         self.assertFalse(outcome)
         self.assertEqual(3, self.counter)


### PR DESCRIPTION
# Description
Refactor tests to use a local RMQ instance instead of configured remote
Allow non-backwards-compat tests to run in parallel
Includes consumer refactoring to better report `is_consuming` state
Adds handling to `select_consumer` to differentiate socket closure on shutdown vs on error
Adds shutdown handling to `select_consumer` to wait for the connection to close before joining the thread
Allows decorated callback methods to be called directly with a dict `body` input
Allows decorating callback functions in addition to methods

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->