### PR TITLE
Reconnect if ioloop fails to get started

### DIFF
--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -207,8 +207,8 @@ class SelectConsumerThread(threading.Thread):
                 self.connection: pika.SelectConnection = self.create_connection()
                 self.connection.ioloop.start()
             except Exception as e:
-                LOG.error(f"Failed to start io loop on consumer thread {self.name!r}: {e}")
-                self._close_connection()
+                LOG.error(f"Failed to start io loop on consumer thread {self.name!r}: {e}, reconnecting")
+                self.reconnect()
 
     def _close_connection(self, mark_consumer_as_dead: bool = True):
         try:

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -140,7 +140,9 @@ class TestSelectConsumer(TestCase):
         self.assertTrue(test_thread.is_consuming)
         self.assertTrue(test_thread.channel.is_open)
 
-        test_thread.join(30)
+        test_thread.join()
+        while not test_thread.is_alive():
+            sleep(0.1)
         self.assertFalse(test_thread.is_consuming)
         self.assertTrue(test_thread.channel.is_closed or
                         test_thread.channel.is_closing)


### PR DESCRIPTION
# Description
When connecting to RabbitMQ using SelectConsumer, sometimes ioloop connection drops, although becomes successful after reconnecting, idea is to make a reconnection request in such cases instead of forcing disconnect
