### PR TITLE
Define `shutdown` method for NeonMQHandler with unit test coverage

### DIFF
--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -147,15 +147,18 @@ class BlockingConsumerThread(threading.Thread):
         """Terminating consumer channel"""
         if self._is_consumer_alive:
             self._close_connection()
-            super(BlockingConsumerThread, self).join(timeout=timeout)
+            threading.Thread.join(self, timeout=timeout)
 
     def _close_connection(self):
         self._is_consumer_alive = False
         try:
             if self.connection and self.connection.is_open:
                 self.connection.close()
+            if self.connection.is_open:
+                raise RuntimeError(f"Connection still open: {self.connection}")
         except pika.exceptions.StreamLostError:
             pass
         except Exception as e:
             LOG.exception(f"Failed to close connection due to unexpected exception: {e}")
         self._consumer_started.clear()
+        LOG.info("Consumer connection closed")

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -60,6 +60,8 @@ class NeonMQHandler(MQConnector):
     def shutdown(self):
         MQConnector.stop(self)
         self.connection.close()
+        if not self.connection.is_closed:
+            raise RuntimeError(f"Connection is still open: {self.connection}")
 
 
 def send_mq_request(vhost: str, request_data: dict, target_queue: str,

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -57,6 +57,10 @@ class NeonMQHandler(MQConnector):
         self.connection = pika.BlockingConnection(
             parameters=self.get_connection_params(vhost))
 
+    def shutdown(self):
+        MQConnector.stop(self)
+        self.connection.close()
+
 
 def send_mq_request(vhost: str, request_data: dict, target_queue: str,
                     response_queue: str = None, timeout: int = 30,


### PR DESCRIPTION
# Description
https://github.com/NeonGeckoCom/neon-iris/pull/65 highlighted that `stop` does not close the connection
`shutdown` provides a method for cleaning up after a `NeonMQHandler` instance with unit test coverage

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->