### PR TITLE
Resolve observed connection errors

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -531,7 +531,7 @@ class MQConnector(ABC):
                                       on_error=on_error, exchange=exchange,
                                       exchange_type=ExchangeType.fanout.value,
                                       exchange_reset=exchange_reset,
-                                      auto_ack=auto_ack, queue_exclusive=True,
+                                      auto_ack=auto_ack, queue_exclusive=False,
                                       skip_on_existing=skip_on_existing,
                                       restart_attempts=restart_attempts)
 

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -460,10 +460,12 @@ class MQConnector(ABC):
 
         if exchange_type == ExchangeType.fanout.value:
             LOG.info(f'Subscriber exchange listener registered: '
-                     f'[name={name},exchange={exchange},vhost={vhost}]')
+                     f'[name={name},exchange={exchange},vhost={vhost},'
+                     f'async={self.async_consumers_enabled}]')
         else:
             LOG.info(f'Consumer queue listener registered: '
-                     f'[name={name},queue={queue},vhost={vhost}]')
+                     f'[name={name},queue={queue},vhost={vhost},'
+                     f'async={self.async_consumers_enabled}]')
 
         self.consumers[name] = self.consumer_thread_cls(**self.consumer_properties[name]['properties'])
 

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -484,6 +484,10 @@ class MQConnector(ABC):
         elif 0 < restart_attempts < consumer_data.get('num_restarted', 0):
             err_msg = 'num restarts exceeded'
             self.consumers.pop(name, None)
+        elif self.consumers[name].queue_exclusive:
+            err_msg = 'Exclusive queue may not be restarted'
+            self.consumers.pop(name, None)
+            # TODO: Register a new subscriber?
         else:
             self.consumers[name] = self.consumer_thread_cls(**consumer_data['properties'])
             self.run_consumers(names=(name,))

--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -158,6 +158,9 @@ class BlockingConsumerThread(threading.Thread):
                 raise RuntimeError(f"Connection still open: {self.connection}")
         except pika.exceptions.StreamLostError:
             pass
+        except AttributeError:
+            # This happens regularly during connection close within `pika`
+            pass
         except Exception as e:
             LOG.exception(f"Failed to close connection due to unexpected exception: {e}")
         self._consumer_started.clear()

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -77,9 +77,9 @@ class SelectConsumerThread(threading.Thread):
         """
         threading.Thread.__init__(self, *args, **kwargs)
         try:
-            self._io_loop = get_event_loop()
+            get_event_loop()
         except RuntimeError:
-            self._io_loop = new_event_loop()
+            set_event_loop(new_event_loop())
         self._consumer_started = Event()  # annotates that ConsumerThread is running
         self._channel_closed = threading.Event()
         self._is_consumer_alive = True  # annotates that ConsumerThread is alive and shall be recreated
@@ -105,8 +105,7 @@ class SelectConsumerThread(threading.Thread):
         return pika.SelectConnection(parameters=self.connection_params,
                                      on_open_callback=self.on_connected,
                                      on_open_error_callback=self.on_connection_fail,
-                                     on_close_callback=self.on_close,
-                                     custom_ioloop=self._io_loop)
+                                     on_close_callback=self.on_close)
 
     def on_connected(self, _):
         """Called when we are fully connected to RabbitMQ"""

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -218,7 +218,9 @@ class SelectConsumerThread(threading.Thread):
             get_event_loop()
         except RuntimeError as e:
             LOG.warning(e)
-            set_event_loop(new_event_loop())
+            loop = new_event_loop()
+            set_event_loop(loop)
+            loop.run_forever()
         if not self.is_consuming:
             try:
                 self.connection: pika.SelectConnection = self.create_connection()

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -82,9 +82,9 @@ class SelectConsumerThread(threading.Thread):
             LOG.warning(e)
             loop = new_event_loop()
             set_event_loop(loop)
-            loop.run_until_complete(self._wait_until_exit)
+            loop.run_forever()
         self._consumer_started = Event()  # annotates that ConsumerThread is running
-        self._exit_event = Event()
+        # self._exit_event = Event()
         self._channel_closed = threading.Event()
         self._is_consumer_alive = True  # annotates that ConsumerThread is alive and shall be recreated
         self._stopping = False
@@ -105,8 +105,8 @@ class SelectConsumerThread(threading.Thread):
         self.connection_failed_attempts = 0
         self.max_connection_failed_attempts = 3
 
-    async def _wait_until_exit(self):
-        await self._exit_event.wait()
+    # async def _wait_until_exit(self):
+    #     await self._exit_event.wait()
 
     def create_connection(self) -> pika.SelectConnection:
         return pika.SelectConnection(parameters=self.connection_params,
@@ -277,7 +277,7 @@ class SelectConsumerThread(threading.Thread):
         """Terminating consumer channel"""
         if self.is_consumer_alive:
             self._close_connection(mark_consumer_as_dead=True)
-        self._exit_event.set()
+        # self._exit_event.set()
         LOG.info(f"Stopped consumer. Waiting up to {timeout}s for thread to terminate.")
         try:
             super().join(timeout=timeout)

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -25,12 +25,10 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
 import threading
 import time
 
-from asyncio import Event
+from asyncio import Event, get_event_loop, set_event_loop, new_event_loop
 from typing import Optional
 
 import pika.exceptions
@@ -205,6 +203,12 @@ class SelectConsumerThread(threading.Thread):
 
     def run(self):
         """Starting connection io loop """
+        try:
+            if get_event_loop() is None:
+                set_event_loop(new_event_loop())
+        except RuntimeError:
+            set_event_loop(new_event_loop())
+
         if not self.is_consuming:
             try:
                 self.connection: pika.SelectConnection = self.create_connection()


### PR DESCRIPTION
# Description
Prevent attempting to restart an exclusive consumer (will fail repeatedly)
Updates subscriber queues to not be exclusive
Ensures an asyncio event loop is always defined in SelectConsumerThreads

# Issues
Noted in Sentry https://neon-ai.sentry.io/issues/6219883443/?project=4507250609356800&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0

# Other Notes
A neon-llm-vllm alpha container is deployed to the alpha namespace with these changes integrated to resolve Sentry logged errors