### PR TITLE
Update logging in select consumer close

### DIFF
--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -198,8 +198,11 @@ class SelectConsumerThread(threading.Thread):
         self._consumer_started.clear()
         if isinstance(e, pika.exceptions.ConnectionClosed):
             LOG.info(f"Connection closed normally: {e}")
+        elif isinstance(e, pika.exceptions.StreamLostError):
+            LOG.warning("MQ connection lost; "
+                        "RabbitMQ is likely temporarily unavailable.")
         else:
-            LOG.error(f"Closing MQ connection due to exception: {e}")
+            LOG.error(f"MQ connection closed due to exception: {e}")
         if not self._stopping:
             # Connection was gracefully closed by the server. Try to re-connect
             LOG.info(f"Trying to reconnect after server closed connection")


### PR DESCRIPTION
# Description
Update StreamLost handling from error to warning to prevent non-actionable errors
Refactor connection close error log to accurately state "closed" instead of "closing" 

# Issues
https://neon-ai.sentry.io/issues/6117742740/events/8741afbd379f439a843d69094c0a63fe/

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->