### PR TITLE
Update default async consumer behavior and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,26 @@ A response may be sent via:
 ```
 Where `<queue>` is the queue to which the response will be published, and `data` is a `bytes` response (generally a `base64`-encoded `dict`).
 
-### [BETA] Asynchronous Consumers
+### Asynchronous Consumers
+By default, async-based consumers handling based on `pika.SelectConnection` will
+be used
 
-Now there is a support for async-based consumers handling based on `pika.SelectConnection`
+#### Override use of async consumers
 
-#### Enabling in a code
+There are a few methods to disable use of async consumers/subscribers.
 
-To enable creation of async consumers/subscribers, set the class-attribute `async_consumers_enabled` to True:
+1. To disable async consumers for a particular class/object, 
+set the class-attribute `async_consumers_enabled` to `False`:
 
-```python
-from neon_mq_connector import MQConnector
+   ```python
+   from neon_mq_connector import MQConnector
+   
+   class MQConnectorChild(MQConnector):
+      async_consumers_enabled  = True
+   ```
+2. To disable the use of async consumers at runtime, set the `MQ_ASYNC_CONSUMERS`
+envvar to `False`
 
-class MQConnectorChild(MQConnector):
-   async_consumers_enabled  = True
-```
+   ```shell
+   export MQ_ASYNC_CONSUMERS=false
+   ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ set the class-attribute `async_consumers_enabled` to `False`:
    from neon_mq_connector import MQConnector
    
    class MQConnectorChild(MQConnector):
-      async_consumers_enabled  = True
+      async_consumers_enabled = False
    ```
 2. To disable the use of async consumers at runtime, set the `MQ_ASYNC_CONSUMERS`
 envvar to `False`

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -65,7 +65,7 @@ class MQConnector(ABC):
     __max_consumer_restarts__ = -1
     __consumer_join_timeout__ = 3
 
-    async_consumers_enabled = False
+    async_consumers_enabled = os.environ.get("MQ_ASYNC_CONSUMERS", True)
 
     @staticmethod
     def init_config(config: Optional[dict] = None) -> dict:

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -82,7 +82,7 @@ class SelectConsumerThread(threading.Thread):
             self._loop = get_event_loop()
             self.__stop_loop_on_exit = False
         except RuntimeError as e:
-            LOG.info(e)
+            LOG.info(f"Creating a new event loop: e={e}")
             self._loop = new_event_loop()
             set_event_loop(self._loop)
             self._loop.run_forever()

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -50,6 +50,14 @@ _default_mq_config = {
 
 
 class NeonMQHandler(MQConnector):
+    """
+    This class is intended for use with `send_mq_request` for simple,
+    transactional reqeusts. Applications needing a persistent connection to
+    MQ services should implement `MQConnector` directly.
+    """
+
+    async_consumers_enabled = False
+
     def __init__(self, config: dict, service_name: str, vhost: str):
         super().__init__(config, service_name)
         self.vhost = vhost

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,8 +35,7 @@ from unittest.mock import Mock
 import pytest
 import pika
 
-from threading import Thread
-
+from threading import Thread, Event
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -137,7 +136,7 @@ class TestClientUtils(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         if cls.test_connector is not None:
-            cls.test_connector.stop_consumers()
+            cls.test_connector.stop()
 
     def test_send_mq_request_valid(self):
         from neon_mq_connector.utils.client_utils import send_mq_request
@@ -190,7 +189,8 @@ class TestClientUtils(unittest.TestCase):
         for p in processes:
             p.join(60)
 
-        self.assertEqual(len(processes), len(responses))
+        self.assertEqual(len(processes), len(responses),
+                         f"len(responses)={len(responses)}")
         for resp in responses.values():
             self.assertTrue(resp['success'], resp.get('reason'))
 


### PR DESCRIPTION
# Description
Update default async behavior to `True`
Read async behavior from envvar `MQ_ASYNC_CONSUMERS`
Update documentation to reflect changes in default and configuration

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->