### PR TITLE
Remove static references to `BlockingConnection` to allow configured `SelectConnection`

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -399,8 +399,12 @@ class MQConnector(ABC):
         """
         if not self.config:
             raise Exception('Configuration is not set')
-        return pika.BlockingConnection(
-            parameters=self.get_connection_params(vhost, **kwargs))
+        if self.async_consumers_enabled:
+            return pika.SelectConnection(
+                parameters=self.get_connection_params(vhost, **kwargs))
+        else:
+            return pika.BlockingConnection(
+                parameters=self.get_connection_params(vhost, **kwargs))
 
     def register_consumer(self, name: str, vhost: str, queue: str,
                           callback: callable,

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -53,9 +53,7 @@ class NeonMQHandler(MQConnector):
     def __init__(self, config: dict, service_name: str, vhost: str):
         super().__init__(config, service_name)
         self.vhost = vhost
-        import pika
-        self.connection = pika.BlockingConnection(
-            parameters=self.get_connection_params(vhost))
+        self.connection = self.create_mq_connection(self.vhost)
 
     def shutdown(self):
         MQConnector.stop(self)


### PR DESCRIPTION
# Description
Update `create_mq_connection` to respect Async consumer setting
Update NeonMQHandler to us async consumer if configured

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->