### PR TITLE
Support Select Connections in `emit_mq_message`

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -326,9 +326,10 @@ class MQConnector(ABC):
             new_channel.close()
 
         if isinstance(connection, pika.BlockingConnection):
-            LOG.info("Using blocking connection")
+            LOG.info(f"Using blocking connection for queue: {queue}")
             _on_channel_open(connection.channel())
         else:
+            LOG.info(f"Using select connection for queue: {queue}")
             connection.channel(on_open_callback=_on_channel_open)
 
         LOG.debug(f"sent message: {request_data['message_id']}")

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -305,6 +305,8 @@ class MQConnector(ABC):
                                 cls.create_unique_id())
 
         def _on_channel_open(new_channel):
+            while not new_channel.is_open:
+                LOG.warning(f"Waiting for channel to open ({new_channel})")
             if exchange:
                 new_channel.exchange_declare(exchange=exchange,
                                              exchange_type=exchange_type,

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -294,6 +294,9 @@ class MQConnector(ABC):
         :raises ValueError: invalid request data provided
         :returns message_id: id of the sent message
         """
+        # Make a copy of request_data to prevent modifying the input object
+        request_data = dict(request_data)
+
         if not isinstance(request_data, dict):
             raise TypeError(f"Expected dict and got {type(request_data)}")
         if not request_data:

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -305,8 +305,6 @@ class MQConnector(ABC):
                                 cls.create_unique_id())
 
         def _on_channel_open(new_channel):
-            while not new_channel.is_open:
-                LOG.warning(f"Waiting for channel to open ({new_channel})")
             if exchange:
                 new_channel.exchange_declare(exchange=exchange,
                                              exchange_type=exchange_type,
@@ -326,10 +324,10 @@ class MQConnector(ABC):
             new_channel.close()
 
         if isinstance(connection, pika.BlockingConnection):
-            LOG.info(f"Using blocking connection for queue: {queue}")
+            LOG.info(f"Using blocking connection for request: {request_data}")
             _on_channel_open(connection.channel())
         else:
-            LOG.info(f"Using select connection for queue: {queue}")
+            LOG.debug(f"Using select connection for queue: {queue}")
             connection.channel(on_open_callback=_on_channel_open)
 
         LOG.debug(f"sent message: {request_data['message_id']}")

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -326,6 +326,7 @@ class MQConnector(ABC):
             new_channel.close()
 
         if isinstance(connection, pika.BlockingConnection):
+            LOG.info("Using blocking connection")
             _on_channel_open(connection.channel())
         else:
             connection.channel(on_open_callback=_on_channel_open)

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -327,7 +327,7 @@ class MQConnector(ABC):
             new_channel.close()
 
         if isinstance(connection, pika.BlockingConnection):
-            LOG.info(f"Using blocking connection for request: {request_data}")
+            LOG.debug(f"Using blocking connection for request: {request_data}")
             _on_channel_open(connection.channel())
         else:
             LOG.debug(f"Using select connection for queue: {queue}")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-pika==1.2.0
+pika~=1.2
 ovos-config~=0.0,>=0.0.8
 ovos-utils~=0.0,>=0.0.32

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -408,7 +408,7 @@ class TestMQConnectorInit(unittest.TestCase):
         callback = Mock(side_effect=lambda *args: callback_event.set())
         connector.register_consumer("test_consumer", vhost=test_vhost,
                                     queue=test_queue, callback=callback)
-        connector.run()
+        connector.run(run_sync=False, run_observer=False)
 
         close_event = threading.Event()
         on_open = Mock()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -410,8 +410,9 @@ class TestMQConnectorInit(unittest.TestCase):
                                     queue=test_queue, callback=callback)
         connector.run(run_sync=False, run_observer=False)
 
+        open_event = threading.Event()
         close_event = threading.Event()
-        on_open = Mock()
+        on_open = Mock(side_effect=lambda *args: open_event.set())
         on_error = Mock()
         on_close = Mock(side_effect=lambda *args: close_event.set())
 
@@ -439,6 +440,8 @@ class TestMQConnectorInit(unittest.TestCase):
         callback_event.clear()
 
         # Async connection emit
+        open_event.wait(timeout=5)
+        self.assertTrue(open_event.is_set())
         on_open.assert_called_once()
         message_id_2 = connector.emit_mq_message(async_connection,
                                                  request_data, queue=test_queue)


### PR DESCRIPTION
# Description
Update `emit_mq_message` to allow either BlockingConnection or SelectConnection objects
Add unit test coverage for `emit_mq_message`

# Issues
- Needs rebase after merge of https://github.com/NeonGeckoCom/neon_mq_connector/pull/113

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->