### PR TITLE
Handle RMQ checks with default vhost

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -576,6 +576,7 @@ class MQConnector(ABC):
                 self.consumers[name].daemon = daemon
                 self.consumers[name].start()
                 self.consumer_properties[name]['started'] = True
+        LOG.debug(f"Started consumers for {self.service_name}")
 
     def stop_consumers(self, names: Optional[tuple] = None):
         """
@@ -596,6 +597,7 @@ class MQConnector(ABC):
                     self.consumer_properties[name]['started'] = False
             except Exception as e:
                 raise ChildProcessError(e)
+        LOG.debug(f"Stopped consumers for {self.service_name}")
 
     @retry(callback_on_exceeded='stop_sync_thread', use_self=True,
            num_retries=__run_retries__)
@@ -705,6 +707,7 @@ class MQConnector(ABC):
         self.stop_sync_thread()
         self.stop_observer_thread()
         self._started = False
+        LOG.info(f"Stopped Connector {self.service_name}")
 
     def pre_run(self, **kwargs):
         """Additional logic invoked before method run()"""


### PR DESCRIPTION
# Description
Add specific handling for RMQ checks without a configured vhost
Add test coverage for `check_rmq_is_available`
Update logging

# Issues
Follow-up to #117 

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->