### PR TITLE
Update to ensure `message_id` is not None

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -303,9 +303,10 @@ class MQConnector(ABC):
             raise ValueError(f'No request data provided')
 
         # Ensure `message_id` in data will match context in messagebus connector
-        request_data.setdefault('message_id', request_data.get("context", {})
-                                .get("mq", {}).get("message_id") or
-                                cls.create_unique_id())
+        if request_data.get('message_id') is None:
+            request_data['message_id'] = \
+                request_data.get("context", {}).get("mq", {}).get("message_id")\
+                or cls.create_unique_id()
 
         def _on_channel_open(new_channel):
             if exchange:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -445,13 +445,30 @@ class TestMQConnectorInit(unittest.TestCase):
         on_open.assert_called_once()
         message_id_2 = connector.emit_mq_message(async_connection,
                                                  request_data, queue=test_queue)
-        self.assertIsInstance(message_id, str)
+        self.assertIsInstance(message_id_2, str)
         self.assertNotEqual(message_id, message_id_2)
         callback_event.wait(timeout=5)
         self.assertTrue(callback_event.is_set())
         callback.assert_called_once()
         self.assertEqual(b64_to_dict(callback.call_args.args[3]),
                          {**request_data, "message_id": message_id_2})
+        callback.reset_mock()
+        callback_event.clear()
+
+        # message_id set to `None`
+        message_id_3 = connector.emit_mq_message(async_connection,
+                                                 {**request_data,
+                                                  "message_id": None},
+                                                 queue=test_queue)
+        self.assertIsInstance(message_id_3, str)
+        self.assertNotEqual("", message_id_3)
+        callback_event.wait(timeout=5)
+        self.assertTrue(callback_event.is_set())
+        callback.assert_called_once()
+        self.assertEqual(b64_to_dict(callback.call_args.args[3]),
+                         {**request_data, "message_id": message_id_3})
+        callback.reset_mock()
+        callback_event.clear()
 
         on_close.assert_not_called()
         connector.stop()


### PR DESCRIPTION
# Description
Ensure `message_id` is always a valid string
Add unit test coverage for `None` value handling

# Issues
`None` value noted in https://neon-ai.sentry.io/issues/6247512848/events/4190e34724534fd181b2369413f5f8b3/

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->