### PR TITLE
Raise unhandled retry exceptions

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -561,6 +561,7 @@ class MQConnector(ABC):
                               exception: Exception):
         LOG.error(f"{exception} occurred in {thread}")
         if isinstance(exception, pika.exceptions.AMQPError):
+            LOG.info("Raising exception to exit")
             # This is a fatal error; raise it so this object can be re-created
             raise exception
 

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -557,8 +557,12 @@ class MQConnector(ABC):
                                       restart_attempts=restart_attempts)
 
     @staticmethod
-    def default_error_handler(thread: ConsumerThreadInstance, exception: Exception):
+    def default_error_handler(thread: ConsumerThreadInstance,
+                              exception: Exception):
         LOG.error(f"{exception} occurred in {thread}")
+        if isinstance(exception, pika.exceptions.AMQPError):
+            # This is a fatal error; raise it so this object can be re-created
+            raise exception
 
     def run_consumers(self, names: Optional[tuple] = None, daemon=True):
         """

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -279,7 +279,8 @@ class SelectConsumerThread(threading.Thread):
             self._is_consumer_alive = False
         else:
             self._stopping = False
-        LOG.info(f"Connection Closed stopping={self._stopping} (t={self.name})")
+        LOG.debug(f"Connection Closed stopping={self._stopping} "
+                  f"(t={self.name})")
 
     def reconnect(self, wait_interval: int = 5):
         self._close_connection(mark_consumer_as_dead=False)

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -206,7 +206,7 @@ class SelectConsumerThread(threading.Thread):
         else:
             LOG.error(f"MQ connection closed due to exception: {e}")
         if not self._stopping:
-            if e.reply_code == 320:
+            if hasattr(e, "reply_code") and e.reply_code == 320:
                 LOG.info(f"Server shutdown. Try to reconnect after 60s (t={self.name})")
                 self.reconnect(60)
             else:

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -230,6 +230,7 @@ class SelectConsumerThread(threading.Thread):
         set_event_loop(self._loop)
         if not self.is_consuming:
             try:
+                LOG.info(f"Starting Consumer: {self.name}")
                 self.connection: pika.SelectConnection = self.create_connection()
                 self.connection.ioloop.start()
             except (pika.exceptions.ChannelClosed,
@@ -274,6 +275,7 @@ class SelectConsumerThread(threading.Thread):
             self._is_consumer_alive = False
         else:
             self._stopping = False
+        LOG.info(f"Connection Closed stopping={self._stopping} (t={self.name})")
 
     def reconnect(self, wait_interval: int = 5):
         self._close_connection(mark_consumer_as_dead=False)

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -233,6 +233,10 @@ class SelectConsumerThread(threading.Thread):
                 LOG.debug(f"Starting Consumer: {self.name}")
                 self.connection: pika.SelectConnection = self.create_connection()
                 self.connection.ioloop.start()
+            except pika.exceptions.StreamLostError as e:
+                # This connection is dead.
+                self._close_connection()
+                self.error_func(self, e)
             except (pika.exceptions.ChannelClosed,
                     pika.exceptions.ConnectionClosed) as e:
                 LOG.info(f"Closed {e.reply_code}: {e.reply_text}")

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -207,7 +207,7 @@ class SelectConsumerThread(threading.Thread):
             LOG.error(f"MQ connection closed due to exception: {e}")
         if not self._stopping:
             if e.reply_code == 320:
-                LOG.info("Server shutdown. Try to reconnect after 60s")
+                LOG.info(f"Server shutdown. Try to reconnect after 60s (t={self.name})")
                 self.reconnect(60)
             else:
                 # Connection was lost or closed by the server. Try to re-connect

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -230,7 +230,7 @@ class SelectConsumerThread(threading.Thread):
         set_event_loop(self._loop)
         if not self.is_consuming:
             try:
-                LOG.info(f"Starting Consumer: {self.name}")
+                LOG.debug(f"Starting Consumer: {self.name}")
                 self.connection: pika.SelectConnection = self.create_connection()
                 self.connection.ioloop.start()
             except (pika.exceptions.ChannelClosed,

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -206,9 +206,13 @@ class SelectConsumerThread(threading.Thread):
         else:
             LOG.error(f"MQ connection closed due to exception: {e}")
         if not self._stopping:
-            # Connection was gracefully closed by the server. Try to re-connect
-            LOG.info(f"Trying to reconnect after server closed connection")
-            self.reconnect()
+            if e.reply_code == 320:
+                LOG.info("Server shutdown. Try to reconnect after 60s")
+                self.reconnect(60)
+            else:
+                # Connection was lost or closed by the server. Try to re-connect
+                LOG.info(f"Trying to reconnect after server connection loss")
+                self.reconnect()
 
     @property
     def is_consumer_alive(self) -> bool:

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -111,7 +111,7 @@ def retry(callback_on_exceeded: Union[str, Callable] = None,
                         info = inspect.getframeinfo(call_frame)
                         LOG.info(
                             f"{error_body} succeeded on try #{num_attempts}\n"
-                            f"{info.__module__}:{info.function}:{info.lineno}")
+                            f"{info.filename}:{info.function}:{info.lineno}")
                     return return_value
                 except Exception as e:
                     for i in range(len(callback_on_attempt_failure_args)):

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -107,7 +107,10 @@ def retry(callback_on_exceeded: Union[str, Callable] = None,
                     else:
                         return_value = function(*args, **kwargs)
                     if num_attempts > 1:
-                        LOG.info(f"{error_body} succeeded on try #{num_attempts}")
+                        call_frame = inspect.currentframe().f_back
+                        info = inspect.getframeinfo(call_frame)
+                        LOG.info(f"{error_body} succeeded on try #{num_attempts}\n"
+                                 f"{info.filename}:{info.function}:{info.lineno}")
                     return return_value
                 except Exception as e:
                     for i in range(len(callback_on_attempt_failure_args)):
@@ -135,7 +138,7 @@ def retry(callback_on_exceeded: Union[str, Callable] = None,
                     sleep_timeout = get_timeout(backoff_factor=backoff_factor,
                                                 number_of_retries=num_attempts)
                     LOG.warning(f'{error_body}: {e}.')
-                    LOG.info(f'Timeout for {sleep_timeout} secs')
+                    LOG.debug(f'Timeout for {sleep_timeout} secs')
                     num_attempts += 1
                     time.sleep(sleep_timeout)
             LOG.error(f'Failed to execute after {num_retries} attempts')

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -103,9 +103,12 @@ def retry(callback_on_exceeded: Union[str, Callable] = None,
                              f'Attempt #{num_attempts}')
                 try:
                     if with_self:
-                        return function(self, *args, **kwargs)
+                        return_value = function(self, *args, **kwargs)
                     else:
-                        return function(*args, **kwargs)
+                        return_value = function(*args, **kwargs)
+                    if num_attempts > 1:
+                        LOG.info(f"Function succeeded on try #{num_attempts}")
+                    return return_value
                 except Exception as e:
                     for i in range(len(callback_on_attempt_failure_args)):
                         if callback_on_attempt_failure_args[i] == 'e':

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -99,15 +99,15 @@ def retry(callback_on_exceeded: Union[str, Callable] = None,
                 error_body = f'{self.__class__.__name__}.{error_body}'
             while num_attempts <= num_retries:
                 if num_attempts > 1:
-                    LOG.info(f'Retrying {function} execution. '
-                             f'Attempt #{num_attempts}')
+                    LOG.debug(f'Retrying {error_body} execution. '
+                              f'Attempt #{num_attempts}')
                 try:
                     if with_self:
                         return_value = function(self, *args, **kwargs)
                     else:
                         return_value = function(*args, **kwargs)
                     if num_attempts > 1:
-                        LOG.info(f"Function succeeded on try #{num_attempts}")
+                        LOG.info(f"{error_body} succeeded on try #{num_attempts}")
                     return return_value
                 except Exception as e:
                     for i in range(len(callback_on_attempt_failure_args)):

--- a/neon_mq_connector/utils/connection_utils.py
+++ b/neon_mq_connector/utils/connection_utils.py
@@ -107,10 +107,11 @@ def retry(callback_on_exceeded: Union[str, Callable] = None,
                     else:
                         return_value = function(*args, **kwargs)
                     if num_attempts > 1:
-                        call_frame = inspect.currentframe().f_back
+                        call_frame = inspect.currentframe().f_back.f_back
                         info = inspect.getframeinfo(call_frame)
-                        LOG.info(f"{error_body} succeeded on try #{num_attempts}\n"
-                                 f"{info.filename}:{info.function}:{info.lineno}")
+                        LOG.info(
+                            f"{error_body} succeeded on try #{num_attempts}\n"
+                            f"{info.__module__}:{info.function}:{info.lineno}")
                     return return_value
                 except Exception as e:
                     for i in range(len(callback_on_attempt_failure_args)):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -304,6 +304,16 @@ class TestMQConnectionUtils(unittest.TestCase):
         self.assertFalse(outcome)
         self.assertEqual(3, self.counter)
 
+        # Retry raises exception
+        @retry(num_retries=1)
+        def _retry_fails():
+            raise Exception("This method is supposed to fail")
+
+        with self.assertRaises(Exception) as e:
+            _retry_fails()
+        self.assertIsInstance(e.exception, RuntimeError)
+        self.assertIn("_retry_fails", repr(e.exception))
+
     def test_wait_for_mq_startup(self):
         self.assertTrue(wait_for_mq_startup("mq.neonaiservices.com", 5672))
         self.assertFalse(wait_for_mq_startup("www.neon.ai", 5672, 1))


### PR DESCRIPTION
# Description
Update `retry` decorator to allow decorating functions and staticmethods
Update `retry` to raise unhandled exceptions with unit test coverage
Update observer to default `False` for SelectConsumer instances that implement their own reconnect logic
Add more specific error handling and logging

# Issues
Closes #125

# Other Notes
Currently deployed with ChatGPT in the alpha namespace