### PR TITLE
Suppress pika error logging around "normal" situations

### DIFF
--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -160,6 +160,9 @@ class BlockingConsumerThread(threading.Thread):
                 raise RuntimeError(f"Connection still open: {self.connection}")
         except pika.exceptions.StreamLostError:
             pass
+        except pika.exceptions.ConnectionClosed:
+            # The connection was already closed
+            pass
         except AttributeError:
             # This happens regularly during connection close within `pika`
             pass

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -36,6 +36,7 @@ from neon_mq_connector.connector import MQConnector
 from ovos_config.config import Configuration
 from ovos_utils.log import LOG
 
+from neon_mq_connector.utils.connection_utils import SuppressPikaLogging
 from neon_mq_connector.utils.network_utils import b64_to_dict
 
 _default_mq_config = {
@@ -160,7 +161,8 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
             if not response_event.is_set():
                 LOG.error(f"Timeout waiting for response to: {message_id} on "
                           f"{response_queue}")
-            neon_api_mq_handler.stop_consumers()
+            with SuppressPikaLogging():
+                neon_api_mq_handler.stop_consumers()
     except ProbableAccessDeniedError:
         raise ValueError(f"{vhost} is not a valid endpoint for "
                          f"{config.get('users').get('mq_handler').get('user')}")


### PR DESCRIPTION
# Description
Add `SuppressPikaLogging` helper class to disable Pika exception logging around specific methods
Add unit test coverage for logging helper class
Ignore `ConnectionClosed` exceptions around connection closure

# Issues
https://neon-ai.sentry.io/issues/6117780109/events/0dc8fa02ee394e8e8e7ac0ce2cab6296/
https://neon-ai.sentry.io/issues/6036780814/events/4bfdd7b2598f4cb1b17304082ce6e295/
https://neon-ai.sentry.io/issues/6036781170/events/4366af6f212145568f08a4d18e1ce29d/
https://neon-ai.sentry.io/issues/6036781181/events/239d88d9bf0f4832aa282da40c48f515/


# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->