### PR TITLE
Update logging and cleanup created MQ Connections

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -480,13 +480,13 @@ class MQConnector(ABC):
         self.consumer_properties[name]['started'] = False
 
         if exchange_type == ExchangeType.fanout.value:
-            LOG.info(f'Subscriber exchange listener registered: '
-                     f'[name={name},exchange={exchange},vhost={vhost},'
-                     f'async={self.async_consumers_enabled}]')
+            LOG.debug(f'Subscriber exchange listener registered: '
+                      f'[name={name},exchange={exchange},vhost={vhost},'
+                      f'async={self.async_consumers_enabled}]')
         else:
-            LOG.info(f'Consumer queue listener registered: '
-                     f'[name={name},queue={queue},vhost={vhost},'
-                     f'async={self.async_consumers_enabled}]')
+            LOG.debug(f'Consumer queue listener registered: '
+                      f'[name={name},queue={queue},vhost={vhost},'
+                      f'async={self.async_consumers_enabled}]')
 
         self.consumers[name] = self.consumer_thread_cls(**self.consumer_properties[name]['properties'])
 

--- a/neon_mq_connector/utils/client_utils.py
+++ b/neon_mq_connector/utils/client_utils.py
@@ -132,6 +132,7 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
             channel.basic_nack(delivery_tag=method.delivery_tag)
             LOG.debug(f"Ignoring {api_output_msg_id} waiting for {message_id}")
 
+    neon_api_mq_handler = None
     try:
         config = Configuration().get('MQ') or _default_mq_config
         if not config['users'].get('mq_handler'):
@@ -168,4 +169,8 @@ def send_mq_request(vhost: str, request_data: dict, target_queue: str,
                          f"{config.get('users').get('mq_handler').get('user')}")
     except Exception as ex:
         LOG.exception(f'Exception occurred while resolving Neon API: {ex}')
+    finally:
+        # Ensure this object is always cleaned up
+        if neon_api_mq_handler:
+            neon_api_mq_handler.shutdown()
     return response_data


### PR DESCRIPTION
# Description
Ensure `send_mq_request` cleans up created connections
Reduce queue creation logs from `INFO` to `DEBUG`

# Issues
Includes test coverage missed in #128 

# Other Notes
Deployed with ChatGPT in the Alpha namespace