### PR TITLE
Add connection close exception handling

### DIFF
--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -160,9 +160,7 @@ class BlockingConsumerThread(threading.Thread):
                 raise RuntimeError(f"Connection still open: {self.connection}")
         except pika.exceptions.StreamLostError:
             pass
-        except (pika.exceptions.ConnectionClosed,
-                pika.exceptions.ConnectionWrongStateError,
-                pika.exceptions.ChannelWrongStateError):
+        except pika.exceptions.ConnectionClosed:
             # The connection was already closed
             pass
         except AttributeError:

--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -160,13 +160,20 @@ class BlockingConsumerThread(threading.Thread):
                 raise RuntimeError(f"Connection still open: {self.connection}")
         except pika.exceptions.StreamLostError:
             pass
-        except pika.exceptions.ConnectionClosed:
+        except (pika.exceptions.ConnectionClosed,
+                pika.exceptions.ConnectionWrongStateError,
+                pika.exceptions.ChannelWrongStateError):
             # The connection was already closed
             pass
         except AttributeError:
             # This happens regularly during connection close within `pika`
             pass
         except Exception as e:
-            LOG.exception(f"Failed to close connection due to unexpected exception: {e}")
+            if self.connection.is_open:
+                LOG.exception(f"Failed to close connection due to unexpected "
+                              f"exception: {e}")
+            else:
+                # Something went wrong, but the connection closed anyway
+                LOG.warning(e)
         self._consumer_started.clear()
         LOG.info("Consumer connection closed")


### PR DESCRIPTION
# Description
Add more exception handling around BlockingConsumerThread connection close to address Sentry logged errors

# Issues
https://neon-ai.sentry.io/issues/6179009031/events/f9a1d4c1a6434f52bbeaf284e7ad7bd0/
https://neon-ai.sentry.io/issues/6328852371/events/7e56c0525e044b718f567db9c1034524/
https://neon-ai.sentry.io/issues/6227576687/events/f58b1fe25f7c4a9690480fa1e88325bc/
https://neon-ai.sentry.io/issues/6328811787/events/ddd3cfe1b37544d080847a5795413d24/
https://neon-ai.sentry.io/issues/6328819692/events/c3db6b5161cd4acaa1f244f891cac4fb/
https://neon-ai.sentry.io/issues/6328874042/events/849532317e58441aace7a9ed5d4ce603/
https://neon-ai.sentry.io/issues/6315750018/events/0ffa39ad2ddc46e384033e6124f4ef29/

# Other Notes
Validated in Alpha with ChatGPT container