### PR TITLE
Raise exception when a consumer fails to restart

### DIFF
--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -549,7 +549,7 @@ class MQConnector(ABC):
             self.consumer_properties[name]['num_restarted'] += 1
         if err_msg:
             self.consumer_properties[name]['dead'] = True
-            LOG.error(f'Cannot restart consumer "{name}" - {err_msg}')
+            raise RuntimeError(err_msg)
 
     def register_subscriber(self, name: str, vhost: str,
                             callback: callable,
@@ -725,7 +725,12 @@ class MQConnector(ABC):
                          and consumer_instance.is_alive()
                          and consumer_instance.is_consumer_alive)):
                 LOG.info(f'Consumer "{consumer_name}" is dead, restarting')
-                self.restart_consumer(name=consumer_name)
+                try:
+                    self.restart_consumer(name=consumer_name)
+                except RuntimeError as e:
+                    raise RuntimeError(
+                            f"Failed to restart consumer {consumer_name}"
+                            ) from e
 
     @property
     def observer_thread(self):


### PR DESCRIPTION
# Description
Raises an exception instead of only logging an error when a consumer fails to restart

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Current behavior logs an error, but does nothing actionable by a class extending MQConnector. This raises an exception when the connector is left in a broken state (all restart attempts have failed) that may be handled.