### PR TITLE
Add `durable` param handling for queues

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
   backwards_compat_tests:
     strategy:
       matrix:
-        python-version: [ '3.8', '3.10']
+        python-version: [ '3.10']
       max-parallel: 1
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -314,6 +314,7 @@ class MQConnector(ABC):
                                              auto_delete=False)
             if queue:
                 declared_queue = new_channel.queue_declare(queue=queue,
+                                                           durable=True,
                                                            auto_delete=False)
                 if exchange_type == ExchangeType.fanout.value:
                     new_channel.queue_bind(queue=declared_queue.method.queue,
@@ -429,6 +430,7 @@ class MQConnector(ABC):
                           exchange: str = None, exchange_type: str = None,
                           exchange_reset: bool = False,
                           queue_exclusive: bool = False,
+                          queue_durable: bool = True,
                           skip_on_existing: bool = False,
                           restart_attempts: int = __max_consumer_restarts__):
         """
@@ -448,6 +450,8 @@ class MQConnector(ABC):
             raised in message handling
         :param auto_ack: Boolean to enable ack of messages upon receipt
         :param queue_exclusive: if Queue needs to be exclusive
+        :param queue_durable: if Queue needs to be durable (required for
+            non-exclusive queues on RabbitMQ 4.3+)
         :param skip_on_existing: to skip if consumer already exists
         :param restart_attempts: max instance restart attempts
             (if < 0 - will restart infinitely times)
@@ -474,6 +478,7 @@ class MQConnector(ABC):
                 error_func=error_handler,
                 auto_ack=auto_ack,
                 queue_exclusive=queue_exclusive,
+                queue_durable=queue_durable,
             )
         self.consumer_properties[name]['restart_attempts'] = int(restart_attempts)
         self.consumer_properties[name]['started'] = False
@@ -584,7 +589,8 @@ class MQConnector(ABC):
                                       on_error=on_error, exchange=exchange,
                                       exchange_type=ExchangeType.fanout.value,
                                       exchange_reset=exchange_reset,
-                                      auto_ack=auto_ack, queue_exclusive=False,
+                                      auto_ack=auto_ack, queue_exclusive=True,
+                                      queue_durable=False,
                                       skip_on_existing=skip_on_existing,
                                       restart_attempts=restart_attempts)
 

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -314,7 +314,6 @@ class MQConnector(ABC):
                                              auto_delete=False)
             if queue:
                 declared_queue = new_channel.queue_declare(queue=queue,
-                                                           durable=True,
                                                            auto_delete=False)
                 if exchange_type == ExchangeType.fanout.value:
                     new_channel.queue_bind(queue=declared_queue.method.queue,

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -430,7 +430,6 @@ class MQConnector(ABC):
                           exchange: str = None, exchange_type: str = None,
                           exchange_reset: bool = False,
                           queue_exclusive: bool = False,
-                          queue_durable: bool = True,
                           skip_on_existing: bool = False,
                           restart_attempts: int = __max_consumer_restarts__):
         """
@@ -449,9 +448,9 @@ class MQConnector(ABC):
         :param on_error: Optional method to handle any exceptions
             raised in message handling
         :param auto_ack: Boolean to enable ack of messages upon receipt
-        :param queue_exclusive: if Queue needs to be exclusive
-        :param queue_durable: if Queue needs to be durable (required for
-            non-exclusive queues on RabbitMQ 4.3+)
+        :param queue_exclusive: if Queue needs to be exclusive. Non-exclusive
+            queues are declared durable automatically for RabbitMQ 4.3+
+            compatibility.
         :param skip_on_existing: to skip if consumer already exists
         :param restart_attempts: max instance restart attempts
             (if < 0 - will restart infinitely times)
@@ -478,7 +477,6 @@ class MQConnector(ABC):
                 error_func=error_handler,
                 auto_ack=auto_ack,
                 queue_exclusive=queue_exclusive,
-                queue_durable=queue_durable,
             )
         self.consumer_properties[name]['restart_attempts'] = int(restart_attempts)
         self.consumer_properties[name]['started'] = False
@@ -589,8 +587,7 @@ class MQConnector(ABC):
                                       on_error=on_error, exchange=exchange,
                                       exchange_type=ExchangeType.fanout.value,
                                       exchange_reset=exchange_reset,
-                                      auto_ack=auto_ack, queue_exclusive=True,
-                                      queue_durable=False,
+                                      auto_ack=auto_ack, queue_exclusive=False,
                                       skip_on_existing=skip_on_existing,
                                       restart_attempts=restart_attempts)
 

--- a/neon_mq_connector/connector.py
+++ b/neon_mq_connector/connector.py
@@ -43,6 +43,7 @@ from ovos_utils.log import LOG
 from neon_mq_connector.config import load_neon_mq_config
 from neon_mq_connector.consumers import BlockingConsumerThread, SelectConsumerThread
 
+from neon_mq_connector.utils import consumer_utils
 from neon_mq_connector.utils.connection_utils import wait_for_mq_startup, retry
 from neon_mq_connector.utils.network_utils import dict_to_b64
 from neon_mq_connector.utils.thread_utils import RepeatingTimer
@@ -313,8 +314,14 @@ class MQConnector(ABC):
                                              exchange_type=exchange_type,
                                              auto_delete=False)
             if queue:
-                declared_queue = new_channel.queue_declare(queue=queue,
-                                                           auto_delete=False)
+                # Producers publish to non-exclusive queues, which must be
+                # durable to match the consumer declaration (RabbitMQ 4.3+
+                # rejects transient non-exclusive queues).
+                declared_queue = new_channel.queue_declare(
+                    queue=queue,
+                    durable=consumer_utils.queue_is_durable(
+                        queue_exclusive=False),
+                    auto_delete=False)
                 if exchange_type == ExchangeType.fanout.value:
                     new_channel.queue_bind(queue=declared_queue.method.queue,
                                            exchange=exchange)

--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -52,6 +52,7 @@ class BlockingConsumerThread(threading.Thread):
                  auto_ack: bool = True,
                  queue_reset: bool = False,
                  queue_exclusive: bool = False,
+                 queue_durable: bool = True,
                  exchange: Optional[str] = None,
                  exchange_reset: bool = False,
                  exchange_type: str = ExchangeType.direct, *args, **kwargs):
@@ -66,6 +67,8 @@ class BlockingConsumerThread(threading.Thread):
         :param queue_reset: If True, delete an existing queue `queue`
         :param queue_exclusive: Marks declared queue as exclusive
             to a given channel (deletes with it)
+        :param queue_durable: Marks declared queue as durable. Required for
+            non-exclusive queues on RabbitMQ 4.3+
         :param exchange: exchange to bind queue to (optional)
         :param exchange_reset: If True, delete an existing exchange `exchange`
         :param exchange_type: type of exchange to bind to from ExchangeType
@@ -89,6 +92,7 @@ class BlockingConsumerThread(threading.Thread):
         self.queue = queue or ''
         self.queue_reset = queue_reset
         self.queue_exclusive = queue_exclusive
+        self.queue_durable = queue_durable
 
         self.connection_params = connection_params
         self.connection = None
@@ -131,6 +135,7 @@ class BlockingConsumerThread(threading.Thread):
         if self.queue_reset:
             self.channel.queue_delete(queue=self.queue)
         declared_queue = self.channel.queue_declare(queue=self.queue,
+                                                    durable=self.queue_durable,
                                                     auto_delete=False,
                                                     exclusive=self.queue_exclusive)
         if self.exchange:

--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -133,7 +133,7 @@ class BlockingConsumerThread(threading.Thread):
             self.channel.queue_delete(queue=self.queue)
         declared_queue = self.channel.queue_declare(
             queue=self.queue,
-            durable=not self.queue_exclusive,
+            durable=consumer_utils.queue_is_durable(self.queue_exclusive),
             auto_delete=False,
             exclusive=self.queue_exclusive)
         if self.exchange:

--- a/neon_mq_connector/consumers/blocking_consumer.py
+++ b/neon_mq_connector/consumers/blocking_consumer.py
@@ -52,7 +52,6 @@ class BlockingConsumerThread(threading.Thread):
                  auto_ack: bool = True,
                  queue_reset: bool = False,
                  queue_exclusive: bool = False,
-                 queue_durable: bool = True,
                  exchange: Optional[str] = None,
                  exchange_reset: bool = False,
                  exchange_type: str = ExchangeType.direct, *args, **kwargs):
@@ -66,9 +65,8 @@ class BlockingConsumerThread(threading.Thread):
         :param auto_ack: Boolean to enable ack of messages upon receipt
         :param queue_reset: If True, delete an existing queue `queue`
         :param queue_exclusive: Marks declared queue as exclusive
-            to a given channel (deletes with it)
-        :param queue_durable: Marks declared queue as durable. Required for
-            non-exclusive queues on RabbitMQ 4.3+
+            to a given channel (deletes with it). Non-exclusive queues are
+            declared durable automatically for RabbitMQ 4.3+ compatibility.
         :param exchange: exchange to bind queue to (optional)
         :param exchange_reset: If True, delete an existing exchange `exchange`
         :param exchange_type: type of exchange to bind to from ExchangeType
@@ -92,7 +90,6 @@ class BlockingConsumerThread(threading.Thread):
         self.queue = queue or ''
         self.queue_reset = queue_reset
         self.queue_exclusive = queue_exclusive
-        self.queue_durable = queue_durable
 
         self.connection_params = connection_params
         self.connection = None
@@ -134,10 +131,11 @@ class BlockingConsumerThread(threading.Thread):
         self.channel.basic_qos(prefetch_count=50)
         if self.queue_reset:
             self.channel.queue_delete(queue=self.queue)
-        declared_queue = self.channel.queue_declare(queue=self.queue,
-                                                    durable=self.queue_durable,
-                                                    auto_delete=False,
-                                                    exclusive=self.queue_exclusive)
+        declared_queue = self.channel.queue_declare(
+            queue=self.queue,
+            durable=not self.queue_exclusive,
+            auto_delete=False,
+            exclusive=self.queue_exclusive)
         if self.exchange:
             if self.exchange_reset:
                 self.channel.exchange_delete(exchange=self.exchange)

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -154,7 +154,7 @@ class SelectConsumerThread(threading.Thread):
     def declare_queue(self, _unused_frame: Optional[Method] = None):
         return self.channel.queue_declare(
             queue=self.queue,
-            durable=not self.queue_exclusive,
+            durable=consumer_utils.queue_is_durable(self.queue_exclusive),
             exclusive=self.queue_exclusive,
                                           auto_delete=False,
                                           callback=self.on_queue_declared)

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -54,6 +54,7 @@ class SelectConsumerThread(threading.Thread):
                  auto_ack: bool = True,
                  queue_reset: bool = False,
                  queue_exclusive: bool = False,
+                 queue_durable: bool = True,
                  exchange: Optional[str] = None,
                  exchange_reset: bool = False,
                  exchange_type: str = ExchangeType.direct,
@@ -69,6 +70,8 @@ class SelectConsumerThread(threading.Thread):
         :param queue_reset: If True, delete an existing queue `queue`
         :param queue_exclusive: Marks declared queue as exclusive
             to a given channel (deletes with it)
+        :param queue_durable: Marks declared queue as durable. Required for
+            non-exclusive queues on RabbitMQ 4.3+
         :param exchange: exchange to bind queue to (optional)
         :param exchange_reset: If True, delete an existing exchange `exchange`
         :param exchange_type: type of exchange to bind to from ExchangeType
@@ -100,6 +103,7 @@ class SelectConsumerThread(threading.Thread):
         self.queue = queue or ''
         self.channel = None
         self.queue_exclusive = queue_exclusive
+        self.queue_durable = queue_durable
         self.auto_ack = auto_ack
 
         self.connection_params = connection_params
@@ -149,6 +153,7 @@ class SelectConsumerThread(threading.Thread):
 
     def declare_queue(self, _unused_frame: Optional[Method] = None):
         return self.channel.queue_declare(queue=self.queue,
+                                          durable=self.queue_durable,
                                           exclusive=self.queue_exclusive,
                                           auto_delete=False,
                                           callback=self.on_queue_declared)

--- a/neon_mq_connector/consumers/select_consumer.py
+++ b/neon_mq_connector/consumers/select_consumer.py
@@ -54,7 +54,6 @@ class SelectConsumerThread(threading.Thread):
                  auto_ack: bool = True,
                  queue_reset: bool = False,
                  queue_exclusive: bool = False,
-                 queue_durable: bool = True,
                  exchange: Optional[str] = None,
                  exchange_reset: bool = False,
                  exchange_type: str = ExchangeType.direct,
@@ -69,9 +68,8 @@ class SelectConsumerThread(threading.Thread):
         :param auto_ack: Boolean to enable ack of messages upon receipt
         :param queue_reset: If True, delete an existing queue `queue`
         :param queue_exclusive: Marks declared queue as exclusive
-            to a given channel (deletes with it)
-        :param queue_durable: Marks declared queue as durable. Required for
-            non-exclusive queues on RabbitMQ 4.3+
+            to a given channel (deletes with it). Non-exclusive queues are
+            declared durable automatically for RabbitMQ 4.3+ compatibility.
         :param exchange: exchange to bind queue to (optional)
         :param exchange_reset: If True, delete an existing exchange `exchange`
         :param exchange_type: type of exchange to bind to from ExchangeType
@@ -103,7 +101,6 @@ class SelectConsumerThread(threading.Thread):
         self.queue = queue or ''
         self.channel = None
         self.queue_exclusive = queue_exclusive
-        self.queue_durable = queue_durable
         self.auto_ack = auto_ack
 
         self.connection_params = connection_params
@@ -113,6 +110,9 @@ class SelectConsumerThread(threading.Thread):
         self.connection: Optional[pika.SelectConnection] = None
         self.connection_failed_attempts = 0
         self.max_connection_failed_attempts = 3
+        # Delay (in seconds) before reconnecting after a broker-initiated
+        # shutdown (AMQP reply code 320). Gives the server time to come back.
+        self.server_shutdown_reconnect_delay = 60
 
     def create_connection(self) -> pika.SelectConnection:
         return pika.SelectConnection(parameters=self.connection_params,
@@ -152,9 +152,10 @@ class SelectConsumerThread(threading.Thread):
         self._channel_closed.set()
 
     def declare_queue(self, _unused_frame: Optional[Method] = None):
-        return self.channel.queue_declare(queue=self.queue,
-                                          durable=self.queue_durable,
-                                          exclusive=self.queue_exclusive,
+        return self.channel.queue_declare(
+            queue=self.queue,
+            durable=not self.queue_exclusive,
+            exclusive=self.queue_exclusive,
                                           auto_delete=False,
                                           callback=self.on_queue_declared)
 
@@ -212,8 +213,10 @@ class SelectConsumerThread(threading.Thread):
             LOG.error(f"MQ connection closed due to exception: {e}")
         if not self._stopping:
             if hasattr(e, "reply_code") and e.reply_code == 320:
-                LOG.info(f"Server shutdown. Try to reconnect after 60s (t={self.name})")
-                self.reconnect(60)
+                LOG.info(f"Server shutdown. Try to reconnect after "
+                         f"{self.server_shutdown_reconnect_delay}s "
+                         f"(t={self.name})")
+                self.reconnect(self.server_shutdown_reconnect_delay)
             else:
                 # Connection was lost or closed by the server. Try to re-connect
                 LOG.info(f"Trying to reconnect after server connection loss")

--- a/neon_mq_connector/utils/consumer_utils.py
+++ b/neon_mq_connector/utils/consumer_utils.py
@@ -30,6 +30,18 @@
 from ovos_utils.log import LOG
 
 
+def queue_is_durable(queue_exclusive: bool) -> bool:
+    """
+    Determine whether a queue should be declared durable. RabbitMQ 4.3+ rejects
+    transient (non-durable) non-exclusive queues, so non-exclusive queues are
+    durable while exclusive queues remain transient (deleted with their
+    declaring connection).
+    :param queue_exclusive: True if the queue is declared exclusive
+    :returns: True if the queue should be declared durable
+    """
+    return not queue_exclusive
+
+
 def default_error_handler(*args):
     """
     Default handler for Consumer instances

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Fail fast on hung tests (e.g. consumers stuck reconnecting) instead of
+# letting the job run until the workflow-level timeout.
+timeout = 120

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest~=8.0
+pytest-timeout~=2.3
 parameterized~=0.9.0
 neon-minerva[rmq]~=0.3

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -29,7 +29,7 @@
 import pytest
 
 from os import environ
-from time import sleep
+from time import monotonic, sleep
 from unittest.mock import Mock
 from unittest import TestCase
 from pika.connection import ConnectionParameters
@@ -39,6 +39,16 @@ from pika.exchange_type import ExchangeType
 from neon_minerva.integration.rabbit_mq import rmq_instance  # noqa: F401
 
 environ["TEST_RMQ_VHOSTS"] = "/neon_testing"
+
+
+class TestQueueDurability(TestCase):
+    def test_queue_is_durable(self):
+        from neon_mq_connector.utils.consumer_utils import queue_is_durable
+        # Non-exclusive queues must be durable (RabbitMQ 4.3+ rejects
+        # transient non-exclusive queues)
+        self.assertTrue(queue_is_durable(queue_exclusive=False))
+        # Exclusive queues are transient (deleted with their connection)
+        self.assertFalse(queue_is_durable(queue_exclusive=True))
 
 
 @pytest.mark.usefixtures("rmq_instance")
@@ -173,6 +183,7 @@ class TestSelectConsumer(TestCase):
         self.assertFalse(test_thread.is_consumer_alive)
         test_thread.on_close.assert_not_called()
 
+    @pytest.mark.timeout(60)
     def test_handle_reconnection(self):
         from neon_mq_connector.consumers.select_consumer import SelectConsumerThread
         connection_params = ConnectionParameters(host='localhost',
@@ -188,6 +199,9 @@ class TestSelectConsumer(TestCase):
         # Valid thread
         test_thread = SelectConsumerThread(connection_params, queue, callback,
                                            error)
+        # Reconnect promptly after the broker shutdown triggered below instead
+        # of the production default (waiting for the server to come back).
+        test_thread.server_shutdown_reconnect_delay = 1
         test_thread.on_connected = Mock(side_effect=test_thread.on_connected)
         test_thread.on_channel_open = Mock(side_effect=test_thread.on_channel_open)
         test_thread.on_close = Mock(side_effect=test_thread.on_close)
@@ -207,8 +221,10 @@ class TestSelectConsumer(TestCase):
         self.assertTrue(test_thread.is_consumer_alive)
 
         self.rmq_instance.start()
-        # TODO: Wait for re-connection
+        reconnect_deadline = monotonic() + 30
         while not test_thread.is_consuming:
+            if monotonic() > reconnect_deadline:
+                self.fail("Consumer did not reconnect within 30s")
             sleep(0.1)
         self.assertTrue(test_thread.is_consuming)
         self.assertTrue(test_thread.is_consumer_alive)


### PR DESCRIPTION
# Description
Expose `queue_durable` with default value of `True`
This flag is required for newer RMQ versions, where `queue_durable` and `queue_exclusive` are mutually exclusive

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Issue observed in logs and resolution implemented by Cursor
- All public deployments and documented instructions use RMQ 3 and are therefore unaffected