### PR TITLE
Remove Python 3.8 from GHA automation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
   backwards_compat_tests:
     strategy:
       matrix:
-        python-version: [ '3.8', '3.10']
+        python-version: [ '3.10']
       max-parallel: 1
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description
Remove Python 3.8 from GHA

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Addresses test failures noted in #101 
- 3.8 went EoL in 2024